### PR TITLE
Make Consumer and BufferedConsumer have the same interface.

### DIFF
--- a/mixpanel/__init__.py
+++ b/mixpanel/__init__.py
@@ -284,6 +284,11 @@ class Consumer(object):
         else:
             raise MixpanelException('No such endpoint "{0}". Valid endpoints are one of {1}'.format(self._endpoints.keys()))
 
+    @staticmethod
+    def flush():
+        """To have the same interface as the BufferedConsumer."""
+        pass
+
     def _write_request(self, request_url, json_message):
         data = urllib.urlencode({
             'data': base64.b64encode(json_message),


### PR DESCRIPTION
It should be possible to switch between the two consumer classes provided without any code change. Currently you'll run into issues if you have implemented the `BufferedConsumer`, with calls to `flush()` where appropriate, and then, for some reason, goes back to the default `Consumer`.
My suggestion is to simply add a dummy `flush()` method to `Consumer`. I made it static since it doesn't use self and it works great with inheritance too.
