### PR TITLE
Made BufferedConsumer's _flush_endpoint more thread-safe by making sure ...

### DIFF
--- a/mixpanel/__init__.py
+++ b/mixpanel/__init__.py
@@ -371,12 +371,13 @@ class BufferedConsumer(object):
     def _flush_endpoint(self, endpoint):
         buf = self._buffers[endpoint]
         while buf:
-            batch = buf[:self._max_size]
+            batch_size = min(len(buf), self._max_size)
+            batch = buf[:batch_size]
             batch_json = '[{0}]'.format(','.join(batch))
             try:
                 self._consumer.send(endpoint, batch_json)
             except MixpanelException as e:
                 e.message = 'batch_json'
                 e.endpoint = endpoint
-            buf = buf[self._max_size:]
+            buf = buf[batch_size:]
         self._buffers[endpoint] = buf


### PR DESCRIPTION
...only events that are sent are cleared from the buffer. This prevents a race condition in the mixpanel-python-async where events were dropped if queued up while other events were being sent. See https://github.com/jessepollak/mixpanel-python-async/issues/4 for more information.