### PR TITLE
Add MixpanelExport and MixpanelRawExport

### DIFF
--- a/mixpanel/__init__.py
+++ b/mixpanel/__init__.py
@@ -6,17 +6,32 @@ import urllib2
 
 """
 The mixpanel package allows you to easily track events and
-update people properties from your python application.
+update people properties from your python application, as well
+as export data from the data export API.
 
 The Mixpanel class is the primary class for tracking events and
 sending people analytics updates.
 
 The Consumer and BufferedConsumer classes allow callers to
 customize the IO characteristics of their tracking.
+
+The MixpanelExport class is the primary class for requesting exported data.
+The MixpanelRawExport class is used for requesting "raw" data exports.
+
+Read more about the data export API here:
+https://mixpanel.com/docs/api-documentation/data-export-api
 """
 
 VERSION = '3.1.2'
 
+from . import export
+MixpanelExport = export.MixpanelExport
+MixpanelRawExport = export.MixpanelRawExport
+
+__all__ = [
+    'Mixpanel', 'MixpanelExport', 'MixpanelRawExport',
+    'MixpanelException', 'Consumer', 'BufferedConsumer',
+]
 
 class Mixpanel(object):
     """

--- a/mixpanel/export.py
+++ b/mixpanel/export.py
@@ -1,0 +1,114 @@
+#! /usr/bin/env python
+#
+# Mixpanel, Inc. -- http://mixpanel.com/
+#
+# Python API client library to consume mixpanel.com analytics data.
+#
+# Copyright 2010-2013 Mixpanel, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import hashlib
+import urllib
+import urllib2
+import time
+try:
+    import json
+except ImportError:
+    import simplejson as json
+
+class Mixpanel(object):
+
+    ENDPOINT = 'http://mixpanel.com/api'
+    VERSION = '2.0'
+
+    def __init__(self, api_key, api_secret):
+        self.api_key = api_key
+        self.api_secret = api_secret
+
+    def request(self, methods, params, format='json'):
+        """
+            methods - List of methods to be joined, e.g. ['events', 'properties', 'values']
+                      will give us http://mixpanel.com/api/2.0/events/properties/values/
+            params - Extra parameters associated with method
+        """
+        params['api_key'] = self.api_key
+        params['expire'] = int(time.time()) + 600   # Grant this request 10 minutes.
+        params['format'] = format
+        if 'sig' in params: del params['sig']
+        params['sig'] = self.hash_args(params)
+
+        request_url = '/'.join([self.ENDPOINT, str(self.VERSION)] + methods) + '/?' + self.unicode_urlencode(params)
+
+        request = urllib2.urlopen(request_url, timeout=120)
+        data = request.read()
+
+        return json.loads(data)
+
+    def unicode_urlencode(self, params):
+        """
+            Convert lists to JSON encoded strings, and correctly handle any
+            unicode URL parameters.
+        """
+        if isinstance(params, dict):
+            params = params.items()
+        for i, param in enumerate(params):
+            if isinstance(param[1], list):
+                params[i] = (param[0], json.dumps(param[1]),)
+
+        return urllib.urlencode(
+            [(k, isinstance(v, unicode) and v.encode('utf-8') or v) for k, v in params]
+        )
+
+    def hash_args(self, args, secret=None):
+        """
+            Hashes arguments by joining key=value pairs, appending a secret, and
+            then taking the MD5 hex digest.
+        """
+        for a in args:
+            if isinstance(args[a], list): args[a] = json.dumps(args[a])
+
+        args_joined = ''
+        for a in sorted(args.keys()):
+            if isinstance(a, unicode):
+                args_joined += a.encode('utf-8')
+            else:
+                args_joined += str(a)
+
+            args_joined += '='
+
+            if isinstance(args[a], unicode):
+                args_joined += args[a].encode('utf-8')
+            else:
+                args_joined += str(args[a])
+
+        hash = hashlib.md5(args_joined)
+
+        if secret:
+            hash.update(secret)
+        elif self.api_secret:
+            hash.update(self.api_secret)
+        return hash.hexdigest()
+
+if __name__ == '__main__':
+    api = Mixpanel(
+        api_key = 'YOUR KEY',
+        api_secret = 'YOUR SECRET'
+    )
+    data = api.request(['events'], {
+        'event' : ['pages',],
+        'unit' : 'hour',
+        'interval' : 24,
+        'type': 'general'
+    })
+    print data

--- a/mixpanel/export.py
+++ b/mixpanel/export.py
@@ -122,3 +122,13 @@ class MixpanelRawExport(MixpanelExport):
         request = self._make_request(['export'], params, format=format)
         data = [json.loads(line) for line in request]
         return data
+
+    def request_generator(self, params, format='json'):
+        """
+        Like request, but yields every line returned as soon as it is read.
+
+            params - Extra parameters
+        """
+        request = self._make_request(['export'], params, format=format)
+        for line in request:
+            yield json.loads(line)

--- a/mixpanel/export.py
+++ b/mixpanel/export.py
@@ -29,7 +29,7 @@ except ImportError:
 
 class MixpanelExport(object):
 
-    ENDPOINT = 'http://mixpanel.com/api'
+    ENDPOINT = 'https://mixpanel.com/api'
     VERSION = '2.0'
 
     def __init__(self, api_key, api_secret):
@@ -109,7 +109,7 @@ class MixpanelExport(object):
 
 class MixpanelRawExport(MixpanelExport):
 
-    ENDPOINT = 'http://data.mixpanel.com/api'
+    ENDPOINT = 'https://data.mixpanel.com/api'
 
     def request(self, params, format='json'):
         """

--- a/mixpanel/export.py
+++ b/mixpanel/export.py
@@ -1,4 +1,3 @@
-#! /usr/bin/env python
 #
 # Mixpanel, Inc. -- http://mixpanel.com/
 #
@@ -99,16 +98,3 @@ class Mixpanel(object):
         elif self.api_secret:
             hash.update(self.api_secret)
         return hash.hexdigest()
-
-if __name__ == '__main__':
-    api = Mixpanel(
-        api_key = 'YOUR KEY',
-        api_secret = 'YOUR SECRET'
-    )
-    data = api.request(['events'], {
-        'event' : ['pages',],
-        'unit' : 'hour',
-        'interval' : 24,
-        'type': 'general'
-    })
-    print data

--- a/tests.py
+++ b/tests.py
@@ -200,6 +200,31 @@ class MixpanelTestCase(unittest.TestCase):
             }
         )])
 
+class MixpanelExportTestCase(unittest.TestCase):
+    def setUp(self):
+        self.client = mixpanel.MixpanelExport('a', 'b')
+
+    @patch('time.time')
+    def test_url_generation(self, mock_time):
+        mock_time.return_value = 123456789
+        url = self.client._make_request_url(['events'], {})
+        self.assertEquals(url, 'https://mixpanel.com/api/2.0/events/?api_key=a&sig=27fcdaadb5fc5ae1ca27024cc04a1331&expire=123457389&format=json')
+
+    def test_arg_hashing(self):
+        hash = self.client.hash_args(dict(api_key='a', format='json', expire=123457389))
+        self.assertEquals(hash, '27fcdaadb5fc5ae1ca27024cc04a1331')
+
+
+class MixpanelRawExportTestCase(unittest.TestCase):
+    def setUp(self):
+        self.client = mixpanel.MixpanelRawExport('a', 'b')
+
+    @patch('time.time')
+    def test_url_generation(self, mock_time):
+        mock_time.return_value = 123456789
+        url = self.client._make_request_url(['export'], {})
+        self.assertEquals(url, 'https://data.mixpanel.com/api/2.0/export/?api_key=a&sig=27fcdaadb5fc5ae1ca27024cc04a1331&expire=123457389&format=json')
+
 class ConsumerTestCase(unittest.TestCase):
     def setUp(self):
         self.consumer = mixpanel.Consumer()


### PR DESCRIPTION
The [Mixpanel data export API](https://mixpanel.com/docs/api-documentation/data-export-api) has a "client library" of its own that is just a Python example script linked from the documentation.

I think it should be part of this client library, so it can be improved via Github.

I've just added the [example script](https://mixpanel.com/site_media//api/v2/mixpanel.py) and a few patches to make it possible to use both the normal export API and the "raw" export API. There are some more things that should be cleaned up, like making the `expire` and `timeout` arguments that can be passed in to `MixpanelExport.request`, but I figured it was better to send the PR quickly to see if you are open to adding this functionality to this library at all.
