### PR TITLE
Converted to py2/py3-compatible package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,11 @@ try:
 except ImportError:
     from distutils.core import setup
 
+from mixpanel import VERSION
+
 setup(
     name='mixpanel-py',
-    version='3.2.0',
+    version=VERSION,
     author='Mixpanel, Inc.',
     author_email='dev@mixpanel.com',
     packages=['mixpanel'],


### PR DESCRIPTION
These changes make the code work in both py2 and py3.  I added exception handling around imports to import the correct functionality from the urllibs. I also added encoding to strings where bytes were now required.

Strangely, 7 of the tests didn't pass for me (4 failures, 3 errors) before making the changes. Those same 7 tests fail/error with the same messages under these changes too.  That's the case for python 2.7.6 (again, with and without my changes) and python 3.4.2.

I bumped the patch version up to 3.2.1 too and changed setup.py to pull in the version from the code instead of redefining it.
