### PR TITLE
Fix missing import in unit tests

### DIFF
--- a/test_mixpanel.py
+++ b/test_mixpanel.py
@@ -7,6 +7,7 @@ import time
 import urlparse
 
 from mock import Mock, patch
+import pytest
 
 import mixpanel
 


### PR DESCRIPTION
pytest was not imported, causing a NameError when trying to report a test failure in qs()