### PR TITLE
Empty buffer after preparing _flush_endpoint in BufferedConsumer

### DIFF
--- a/mixpanel/__init__.py
+++ b/mixpanel/__init__.py
@@ -440,6 +440,7 @@ class BufferedConsumer(object):
 
     def _flush_endpoint(self, endpoint):
         buf = self._buffers[endpoint]
+        self._buffers[endpoint] = []
         while buf:
             batch = buf[:self._max_size]
             batch_json = '[{0}]'.format(','.join(batch))
@@ -451,4 +452,3 @@ class BufferedConsumer(object):
                 mp_e.endpoint = endpoint
                 raise six.raise_from(mp_e, orig_e)
             buf = buf[self._max_size:]
-        self._buffers[endpoint] = buf


### PR DESCRIPTION
An asynchronous buffered consumer will duplicate messages if it is flushed while an earlier call to _flush_endpoint is being processed asynchronously. Discovered this while using [mixpanel-python-async](https://github.com/jessepollak/mixpanel-python-async).

By emptying the buffer before iterating over the messages, subsequent calls to _flush_endpoint while async call(s) are already in progress will not duplicate messages.