### PR TITLE
Handle api_key in BufferedConsumer

### DIFF
--- a/test_mixpanel.py
+++ b/test_mixpanel.py
@@ -394,10 +394,11 @@ class TestBufferedConsumer:
             assert excinfo.value.message == '[%s]' % broken_json
             assert excinfo.value.endpoint == 'events'
 
-    def test_import_data_receives_api_key(self):
-        # Ensure BufferedConsumer.send accepts the API_KEY parameter needed for
-        # import_data; see #62.
+    def test_send_remembers_api_key(self):
         self.consumer.send('imports', '"Event"', api_key='MY_API_KEY')
+        assert len(self.log) == 0
+        self.consumer.flush()
+        assert self.log == [('imports', ['Event'], 'MY_API_KEY')]
 
 
 class TestFunctional:


### PR DESCRIPTION
Previously, `import_data` would often fail when using a `BufferedConsumer`, because `flush` had no way to know about the `api_key` needed for that endpoint. Now we remember the last `api_key` we've seen, and pass it along to the backing consumer. Fixes #63.
