### PR TITLE
Test Python3.6, no longer test Python2.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ build
 dist
 docs/_build
 .idea/
+.cache/
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build
 dist
 docs/_build
 .idea/
+

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 build
 dist
 docs/_build
+.idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
-  - "3.3"
   - "3.4"
+  - "3.5"
+  - "3.6"
 install:
   - "pip install ."
   - "pip install -r requirements-testing.txt"

--- a/test_mixpanel.py
+++ b/test_mixpanel.py
@@ -287,7 +287,7 @@ class TestMixpanel:
         decimal_string = '12.05'
         with pytest.raises(TypeError) as excinfo:
             self.mp.track('ID', 'button press', {'size': decimal.Decimal(decimal_string)})
-        assert "Decimal('%s') is not JSON serializable" % decimal_string in str(excinfo.value)
+        assert "not JSON serializable" in str(excinfo.value)
 
         class CustomSerializer(mixpanel.DatetimeSerializer):
             def default(self, obj):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py34, py35
+envlist = py27, py34, py35, py36
 
 [testenv]
 deps = -rrequirements-testing.txt


### PR DESCRIPTION
Added tests for Python 3.6.  While there may be Python 2.6 still in production, those projects won't be installing new versions of the mixpanel library so I took that out.