### PR TITLE
Retry support

### DIFF
--- a/mixpanel/__init__.py
+++ b/mixpanel/__init__.py
@@ -66,7 +66,7 @@ class Mixpanel(object):
         return time.time()
 
     def _make_insert_id(self):
-        return uuid.uuid1().hex
+        return uuid.uuid4().hex
 
     def track(self, distinct_id, event_name, properties=None, meta=None):
         """Record an event.

--- a/mixpanel/__init__.py
+++ b/mixpanel/__init__.py
@@ -492,7 +492,7 @@ class Consumer(object):
 
     def _write_request(self, request_url, json_message, api_key=None):
         data = {
-            'data': json_message.encode('utf8'),
+            'data': json_message,
             'verbose': 1,
             'ip': 0,
         }

--- a/mixpanel/__init__.py
+++ b/mixpanel/__init__.py
@@ -357,7 +357,6 @@ class Mixpanel(object):
             record.update(meta)
         self._consumer.send('people', json_dumps(record, cls=self._serializer))
 
-
     def group_set(self, group_key, group_id, properties, meta=None):
         """Set properties of a group profile.
 
@@ -530,7 +529,7 @@ class Consumer(object):
         """Immediately record an event or a profile update.
 
         :param endpoint: the Mixpanel API endpoint appropriate for the message
-        :type endpoint: "events" | "people" | "imports"
+        :type endpoint: "events" | "people" | "groups" | "imports"
         :param str json_message: a JSON message formatted for the endpoint
         :param str api_key: your Mixpanel project's API key
         :raises MixpanelException: if the endpoint doesn't exist, the server is
@@ -623,7 +622,7 @@ class BufferedConsumer(object):
         :meth:`~.send`.
 
         :param endpoint: the Mixpanel API endpoint appropriate for the message
-        :type endpoint: "events" | "people" | "imports"
+        :type endpoint: "events" | "people" | "groups" | "imports"
         :param str json_message: a JSON message formatted for the endpoint
         :param str api_key: your Mixpanel project's API key
         :raises MixpanelException: if the endpoint doesn't exist, the server is

--- a/mixpanel/__init__.py
+++ b/mixpanel/__init__.py
@@ -20,7 +20,6 @@ import json
 import time
 
 import six
-from six.moves import urllib
 import urllib3
 
 __version__ = '4.5.0'

--- a/mixpanel/__init__.py
+++ b/mixpanel/__init__.py
@@ -500,12 +500,12 @@ class Consumer(object):
             data.update({'api_key': api_key})
 
         try:
-            r = self._http.request('GET', request_url, fields=data)
+            r = self._http.request('POST', request_url, fields=data, encode_multipart=False)
         except Exception as e:
             six.raise_from(MixpanelException(e), e)
 
         try:
-            response = json.loads(r.data.decode('utf8'))
+            response = json.loads(r.data.decode('utf-8'))
         except ValueError:
             raise MixpanelException('Cannot interpret Mixpanel server response: {0}'.format(response))
 

--- a/mixpanel/__init__.py
+++ b/mixpanel/__init__.py
@@ -20,6 +20,7 @@ import datetime
 import json
 import time
 
+import requests
 import six
 from six.moves import urllib
 
@@ -498,16 +499,9 @@ class Consumer(object):
         }
         if api_key:
             data.update({'api_key': api_key})
-        encoded_data = urllib.parse.urlencode(data).encode('utf8')
-        try:
-            request = urllib.request.Request(request_url, encoded_data)
 
-            # Note: We don't send timeout=None here, because the timeout in urllib2 defaults to
-            # an internal socket timeout, not None.
-            if self._request_timeout is not None:
-                response = urllib.request.urlopen(request, timeout=self._request_timeout).read()
-            else:
-                response = urllib.request.urlopen(request).read()
+        requests.post(request_url, data=data, timeout=self._request_timeout)
+
         except urllib.error.URLError as e:
             six.raise_from(MixpanelException(e), e)
 

--- a/mixpanel/__init__.py
+++ b/mixpanel/__init__.py
@@ -497,9 +497,9 @@ class Consumer(object):
     :param str api_host: the Mixpanel API domain where all requests should be
         issued (unless overridden by above URLs).
     :param int retry_limit: number of times to retry each retry in case of
-        connection or HTTP 5xx error.
+        connection or HTTP 5xx error; 0 to fail after first attempt.
     :param int retry_backoff_factor: In case of retries, controls sleep time. e.g.,
-        sleep seconds = {backoff_factor} * (2 ** ({num total retries} - 1)).
+        sleep_seconds = backoff_factor * (2 ^ (num_total_retries - 1)).
 
     .. versionadded:: 4.6.0
         The *api_host* parameter.
@@ -507,7 +507,7 @@ class Consumer(object):
 
     def __init__(self, events_url=None, people_url=None, import_url=None,
             request_timeout=None, groups_url=None, api_host="api.mixpanel.com",
-            retry_limit=5, retry_backoff_factor=0.0):
+            retry_limit=4, retry_backoff_factor=0.25):
         # TODO: With next major version, make the above args kwarg-only, and reorder them.
         self._endpoints = {
             'events': events_url or 'https://{}/track'.format(api_host),
@@ -587,9 +587,9 @@ class BufferedConsumer(object):
     :param str api_host: the Mixpanel API domain where all requests should be
         issued (unless overridden by above URLs).
     :param int retry_limit: number of times to retry each retry in case of
-        connection or HTTP 5xx error.
+        connection or HTTP 5xx error; 0 to fail after first attempt.
     :param int retry_backoff_factor: In case of retries, controls sleep time. e.g.,
-        sleep seconds = {backoff_factor} * (2 ** ({num total retries} - 1)).
+        sleep_seconds = backoff_factor * (2 ^ (num_total_retries - 1)).
 
     .. versionadded:: 4.6.0
         The *api_host* parameter.
@@ -602,7 +602,7 @@ class BufferedConsumer(object):
     """
     def __init__(self, max_size=50, events_url=None, people_url=None, import_url=None,
             request_timeout=None, groups_url=None, api_host="api.mixpanel.com",
-            retry_limit=5, retry_backoff_factor=0.0):
+            retry_limit=4, retry_backoff_factor=0.25):
         self._consumer = Consumer(events_url, people_url, import_url, request_timeout,
             groups_url, api_host, retry_limit, retry_backoff_factor)
         self._buffers = {

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,10 @@ setup(
     author='Mixpanel, Inc.',
     author_email='dev@mixpanel.com',
     license='Apache',
-    install_requires=['six >= 1.9.0'],
+    install_requires=[
+        'six >= 1.9.0',
+        'requests >= 2.0.0',
+    ],
 
     classifiers=[
         'License :: OSI Approved :: Apache Software License',

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     license='Apache',
     install_requires=[
         'six >= 1.9.0',
-        'requests >= 2.0.0',
+        'urllib3 >= 1.21.1',
     ],
 
     classifiers=[

--- a/test_mixpanel.py
+++ b/test_mixpanel.py
@@ -444,9 +444,6 @@ class TestConsumer:
             assert method == 'POST'
             assert url == expect_url
             assert kwargs["fields"] == expect_data
-            # FIXME
-            # timeout = kwargs.get('timeout', None)
-            # assert timeout == self.consumer._request_timeout
 
     def test_send_events(self):
         with self._assertSends('https://api.mixpanel.com/track', {"ip": 0, "verbose": 1, "data": '{"foo":"bar"}'}):

--- a/test_mixpanel.py
+++ b/test_mixpanel.py
@@ -10,6 +10,7 @@ from mock import Mock, patch
 import pytest
 import six
 from six.moves import range
+import urllib3
 
 import mixpanel
 
@@ -444,7 +445,6 @@ class TestConsumer:
 
 
 class TestBufferedConsumer:
-
     @classmethod
     def setup_class(cls):
         cls.MAX_LENGTH = 10

--- a/test_mixpanel.py
+++ b/test_mixpanel.py
@@ -32,7 +32,7 @@ class TestMixpanel:
 
     def setup_method(self, method):
         self.consumer = LogConsumer()
-        self.mp = mixpanel.Mixpanel('12345', consumer=self.consumer)
+        self.mp = mixpanel.Mixpanel(self.TOKEN, consumer=self.consumer)
         self.mp._now = lambda: 1000.1
 
     def test_track(self):
@@ -52,6 +52,13 @@ class TestMixpanel:
                 }
             }
         )]
+
+    def test_track_makes_insert_id(self):
+        self.mp.track('ID', 'button press', {'size': 'big'})
+        props = self.consumer.log[0][1]["properties"]
+        assert "$insert_id" in props
+        assert isinstance(props["$insert_id"], str)
+        assert len(props["$insert_id"]) > 0
 
     def test_import_data(self):
         timestamp = time.time()

--- a/test_mixpanel.py
+++ b/test_mixpanel.py
@@ -261,6 +261,7 @@ class TestMixpanel:
             assert req.call_count == 1
             ((method, url), kwargs) = req.call_args
 
+            assert method == 'POST'
             assert url == 'https://api.mixpanel.com/track'
             expected_data = {"event":"$create_alias","properties":{"alias":"ALIAS","token":"12345","distinct_id":"ORIGINAL ID"}}
             assert json.loads(kwargs["fields"]["data"]) == expected_data
@@ -393,6 +394,7 @@ class TestConsumer:
             assert req.call_count == 1
             (call_args, kwargs) = req.call_args
             (method, url) = call_args
+            assert method == 'POST'
             assert url == expect_url
             assert kwargs["fields"] == expect_data
             # FIXME
@@ -483,7 +485,7 @@ class TestFunctional:
             assert req.call_count == 1
             ((method, url,), data) = req.call_args
             data = data["fields"]["data"]
-            assert method == 'GET'
+            assert method == 'POST'
             assert url == expect_url
             payload = json.loads(data)
             assert payload == expect_data

--- a/test_mixpanel.py
+++ b/test_mixpanel.py
@@ -57,7 +57,7 @@ class TestMixpanel:
         self.mp.track('ID', 'button press', {'size': 'big'})
         props = self.consumer.log[0][1]["properties"]
         assert "$insert_id" in props
-        assert isinstance(props["$insert_id"], str)
+        assert isinstance(props["$insert_id"], six.text_types)
         assert len(props["$insert_id"]) > 0
 
     def test_import_data(self):

--- a/test_mixpanel.py
+++ b/test_mixpanel.py
@@ -263,7 +263,7 @@ class TestMixpanel:
 
             assert url == 'https://api.mixpanel.com/track'
             expected_data = {"event":"$create_alias","properties":{"alias":"ALIAS","token":"12345","distinct_id":"ORIGINAL ID"}}
-            assert json.loads(kwargs["fields"]["data"].decode("utf-8")) == expected_data
+            assert json.loads(kwargs["fields"]["data"]) == expected_data
 
     def test_people_meta(self):
         self.mp.people_set('amq', {'birth month': 'october', 'favorite color': 'purple'},
@@ -400,11 +400,11 @@ class TestConsumer:
             # assert timeout == self.consumer._request_timeout
 
     def test_send_events(self):
-        with self._assertSends('https://api.mixpanel.com/track', {"ip": 0, "verbose": 1, "data": b'{"foo":"bar"}'}):
+        with self._assertSends('https://api.mixpanel.com/track', {"ip": 0, "verbose": 1, "data": '{"foo":"bar"}'}):
             self.consumer.send('events', '{"foo":"bar"}')
 
     def test_send_people(self):
-        with self._assertSends('https://api.mixpanel.com/engage', {"ip": 0, "verbose": 1, "data": b'{"foo":"bar"}'}):
+        with self._assertSends('https://api.mixpanel.com/engage', {"ip": 0, "verbose": 1, "data": '{"foo":"bar"}'}):
             self.consumer.send('people', '{"foo":"bar"}')
 
     def test_unknown_endpoint(self):
@@ -485,7 +485,7 @@ class TestFunctional:
             data = data["fields"]["data"]
             assert method == 'GET'
             assert url == expect_url
-            payload = json.loads(data.decode("utf-8"))
+            payload = json.loads(data)
             assert payload == expect_data
 
     def test_track_functional(self):

--- a/test_mixpanel.py
+++ b/test_mixpanel.py
@@ -36,7 +36,7 @@ class TestMixpanel:
         self.mp._now = lambda: 1000.1
 
     def test_track(self):
-        self.mp.track('ID', 'button press', {'size': 'big', 'color': 'blue'})
+        self.mp.track('ID', 'button press', {'size': 'big', 'color': 'blue', '$insert_id': 'abc123'})
         assert self.consumer.log == [(
             'events', {
                 'event': 'button press',
@@ -46,6 +46,7 @@ class TestMixpanel:
                     'color': 'blue',
                     'distinct_id': 'ID',
                     'time': int(self.mp._now()),
+                    '$insert_id': 'abc123',
                     'mp_lib': 'python',
                     '$lib_version': mixpanel.__version__,
                 }
@@ -54,7 +55,7 @@ class TestMixpanel:
 
     def test_import_data(self):
         timestamp = time.time()
-        self.mp.import_data('MY_API_KEY', 'ID', 'button press', timestamp, {'size': 'big', 'color': 'blue'})
+        self.mp.import_data('MY_API_KEY', 'ID', 'button press', timestamp, {'size': 'big', 'color': 'blue', '$insert_id': 'abc123'})
         assert self.consumer.log == [(
             'imports', {
                 'event': 'button press',
@@ -64,6 +65,7 @@ class TestMixpanel:
                     'color': 'blue',
                     'distinct_id': 'ID',
                     'time': int(timestamp),
+                    '$insert_id': 'abc123',
                     'mp_lib': 'python',
                     '$lib_version': mixpanel.__version__,
                 },
@@ -72,7 +74,7 @@ class TestMixpanel:
         )]
 
     def test_track_meta(self):
-        self.mp.track('ID', 'button press', {'size': 'big', 'color': 'blue'},
+        self.mp.track('ID', 'button press', {'size': 'big', 'color': 'blue', '$insert_id': 'abc123'},
                       meta={'ip': 0})
         assert self.consumer.log == [(
             'events', {
@@ -83,6 +85,7 @@ class TestMixpanel:
                     'color': 'blue',
                     'distinct_id': 'ID',
                     'time': int(self.mp._now()),
+                    '$insert_id': 'abc123',
                     'mp_lib': 'python',
                     '$lib_version': mixpanel.__version__,
                 },
@@ -379,7 +382,7 @@ class TestMixpanel:
                     return obj.to_eng_string()
 
         self.mp._serializer = CustomSerializer
-        self.mp.track('ID', 'button press', {'size': decimal.Decimal(decimal_string)})
+        self.mp.track('ID', 'button press', {'size': decimal.Decimal(decimal_string), '$insert_id': 'abc123'})
         assert self.consumer.log == [(
             'events', {
                 'event': 'button press',
@@ -388,6 +391,7 @@ class TestMixpanel:
                     'size': decimal_string,
                     'distinct_id': 'ID',
                     'time': int(self.mp._now()),
+                    '$insert_id': 'abc123',
                     'mp_lib': 'python',
                     '$lib_version': mixpanel.__version__,
                 }
@@ -517,9 +521,9 @@ class TestFunctional:
             assert payload == expect_data
 
     def test_track_functional(self):
-        expect_data = {'event': {'color': 'blue', 'size': 'big'}, 'properties': {'mp_lib': 'python', 'token': '12345', 'distinct_id': 'button press', '$lib_version': mixpanel.__version__, 'time': 1000}}
+        expect_data = {'event': 'button_press', 'properties': {'size': 'big', 'color': 'blue', 'mp_lib': 'python', 'token': '12345', 'distinct_id': 'player1', '$lib_version': mixpanel.__version__, 'time': 1000, '$insert_id': 'xyz1200'}}
         with self._assertRequested('https://api.mixpanel.com/track', expect_data):
-            self.mp.track('button press', {'size': 'big', 'color': 'blue'})
+            self.mp.track('player1', 'button_press', {'size': 'big', 'color': 'blue', '$insert_id': 'xyz1200'})
 
     def test_people_set_functional(self):
         expect_data = {'$distinct_id': 'amq', '$set': {'birth month': 'october', 'favorite color': 'purple'}, '$time': 1000000, '$token': '12345'}

--- a/test_mixpanel.py
+++ b/test_mixpanel.py
@@ -481,13 +481,11 @@ class TestFunctional:
             yield
 
             assert req.call_count == 1
-            print(req.call_args)
             ((method, url,), data) = req.call_args
             data = data["fields"]["data"]
-            print(method, url, data)
             assert method == 'GET'
             assert url == expect_url
-            payload = json.loads(data)
+            payload = json.loads(data.decode("utf-8"))
             assert payload == expect_data
 
     def test_track_functional(self):

--- a/test_mixpanel.py
+++ b/test_mixpanel.py
@@ -9,7 +9,6 @@ import time
 from mock import Mock, patch
 import pytest
 import six
-import urllib3
 from six.moves import range
 
 import mixpanel


### PR DESCRIPTION
(Addresses #80)

If we form an $insert_id (or use the one the caller provided), we can retry requests that failed due to certain transport/HTTP errors.
I am adding a dependency on `urllib3` to handle the retry/backoff logic.

- [x] move to urllib3
- [x] ditch base64 encoding, now that tracking API supports urlencoded JSON.
- [x] form `$insert_id` if not given
- [x] retry support
- [ ] basic test for working retries
- [x] caller configurability for retry/timeout params:
   - [x] timeout ("total" connection+request timeout per urllib3 terminology)
   - [x] retry: backoff time factor
   - [x] retry: max retries
- [x] make timeout settings work under urllib3