### PR TITLE
For subclasser compatibility, cram (key,secret) into api_key param.

### DIFF
--- a/mixpanel/__init__.py
+++ b/mixpanel/__init__.py
@@ -152,7 +152,7 @@ class Mixpanel(object):
         if meta:
             event.update(meta)
 
-        self._consumer.send('imports', json_dumps(event, cls=self._serializer), (api_key, api_secret), api_secret)
+        self._consumer.send('imports', json_dumps(event, cls=self._serializer), (api_key, api_secret))
 
     def alias(self, alias_id, original, meta=None):
         """Creates an alias which Mixpanel will use to remap one id to another.
@@ -221,7 +221,7 @@ class Mixpanel(object):
         }
         if meta:
             event.update(meta)
-        self._consumer.send('imports', json_dumps(event, cls=self._serializer), (api_key, api_secret), api_secret)
+        self._consumer.send('imports', json_dumps(event, cls=self._serializer), (api_key, api_secret))
 
     def people_set(self, distinct_id, properties, meta=None):
         """Set properties of a people record.
@@ -690,6 +690,9 @@ class BufferedConsumer(object):
         if endpoint not in self._buffers:
             raise MixpanelException('No such endpoint "{0}". Valid endpoints are one of {1}'.format(endpoint, self._buffers.keys()))
 
+        if not isinstance(api_key, tuple):
+            api_key = (api_key, api_secret)
+
         buf = self._buffers[endpoint]
         buf.append(json_message)
         # Fixme: Don't stick these in the instance.
@@ -708,19 +711,13 @@ class BufferedConsumer(object):
             self._flush_endpoint(endpoint)
 
     def _flush_endpoint(self, endpoint):
-        if isinstance(self._api_key, tuple):
-            api_key, api_secret = self._api_key
-        else:
-            api_key = self._api_key
-            api_secret = self._api_secret
-
         buf = self._buffers[endpoint]
 
         while buf:
             batch = buf[:self._max_size]
             batch_json = '[{0}]'.format(','.join(batch))
             try:
-                self._consumer.send(endpoint, batch_json, api_key, api_secret)
+                self._consumer.send(endpoint, batch_json, api_key=self._api_key)
             except MixpanelException as orig_e:
                 mp_e = MixpanelException(orig_e)
                 mp_e.message = batch_json

--- a/test_mixpanel.py
+++ b/test_mixpanel.py
@@ -21,10 +21,11 @@ class LogConsumer(object):
 
     def send(self, endpoint, event, api_key=None, api_secret=None):
         entry = [endpoint, json.loads(event)]
-        if api_key:
-            entry.append(api_key)
-        if api_secret:
-            entry.append(api_secret)
+        if api_key != (None, None):
+            if api_key:
+                entry.append(api_key)
+            if api_secret:
+                entry.append(api_secret)
         self.log.append(tuple(entry))
 
     def clear(self):
@@ -101,7 +102,6 @@ class TestMixpanel:
                 },
             },
             ('MY_API_KEY', 'MY_SECRET'),
-            'MY_SECRET',
         )]
 
     def test_track_meta(self):
@@ -328,7 +328,6 @@ class TestMixpanel:
                 }
             },
             ('my_good_api_key', 'my_secret'),
-            'my_secret',
         )]
 
     def test_people_meta(self):
@@ -537,13 +536,13 @@ class TestBufferedConsumer:
         self.consumer.send('imports', '"Event"', api_key='MY_API_KEY')
         assert len(self.log) == 0
         self.consumer.flush()
-        assert self.log == [('imports', ['Event'], 'MY_API_KEY')]
+        assert self.log == [('imports', ['Event'], ('MY_API_KEY', None))]
 
     def test_send_remembers_api_secret(self):
         self.consumer.send('imports', '"Event"', api_secret='ZZZZZZ')
         assert len(self.log) == 0
         self.consumer.flush()
-        assert self.log == [('imports', ['Event'], 'ZZZZZZ')]
+        assert self.log == [('imports', ['Event'], (None, 'ZZZZZZ'))]
 
 
 

--- a/test_mixpanel.py
+++ b/test_mixpanel.py
@@ -16,7 +16,6 @@ import mixpanel
 
 
 class LogConsumer(object):
-
     def __init__(self):
         self.log = []
 
@@ -27,6 +26,9 @@ class LogConsumer(object):
         if api_secret:
             entry.append(api_secret)
         self.log.append(tuple(entry))
+
+    def clear(self):
+        self.log = []
 
 
 class TestMixpanel:
@@ -98,7 +100,7 @@ class TestMixpanel:
                     '$lib_version': mixpanel.__version__,
                 },
             },
-            'MY_API_KEY',
+            ('MY_API_KEY', 'MY_SECRET'),
             'MY_SECRET',
         )]
 
@@ -301,7 +303,6 @@ class TestMixpanel:
 
     def test_merge(self):
         self.mp.merge('my_good_api_key', 'd1', 'd2')
-
         assert self.consumer.log == [(
             'imports',
             {
@@ -311,7 +312,23 @@ class TestMixpanel:
                     'token': self.TOKEN,
                 }
             },
-            'my_good_api_key',
+            ('my_good_api_key', None),
+        )]
+
+        self.consumer.clear()
+
+        self.mp.merge('my_good_api_key', 'd1', 'd2', api_secret='my_secret')
+        assert self.consumer.log == [(
+            'imports',
+            {
+                'event': '$merge',
+                'properties': {
+                    '$distinct_ids': ['d1', 'd2'],
+                    'token': self.TOKEN,
+                }
+            },
+            ('my_good_api_key', 'my_secret'),
+            'my_secret',
         )]
 
     def test_people_meta(self):


### PR DESCRIPTION
Ref: #91.

Some subclassers, notably mixpanel-python-async, have overridden `send()` and are thus not constructing the instance vars as expected by mixpanel-python. To unblock these, just form api_key = (key, secret) and sniff/unpack as necessary in the flush/send functions.

Not a great solution but a stopgap until the next major version.