### PR TITLE
Fix https://github.com/mixpanel/mixpanel-python/issues/94

### DIFF
--- a/mixpanel/__init__.py
+++ b/mixpanel/__init__.py
@@ -558,7 +558,7 @@ class Consumer(object):
         self._http = urllib3.PoolManager(
             retries=retry_config,
             timeout=urllib3.Timeout(request_timeout),
-            cert_reqs=cert_reqs,
+            cert_reqs=str(cert_reqs),
         )
 
     def send(self, endpoint, json_message, api_key=None, api_secret=None):


### PR DESCRIPTION
Convert req_cert to plain string, so it's compatible with urllib3 instance(.., str) check