### PR TITLE
Only disable InsecureRequestWarning when verify_cert=False.

### DIFF
--- a/mixpanel/__init__.py
+++ b/mixpanel/__init__.py
@@ -65,8 +65,6 @@ class Mixpanel(object):
         self._consumer = consumer or Consumer()
         self._serializer = serializer
 
-        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-
     def _now(self):
         return time.time()
 
@@ -565,6 +563,9 @@ class Consumer(object):
 
         retry_args[methods_arg] = {"POST"}
         retry_config = urllib3.Retry(**retry_args)
+
+        if not verify_cert:
+            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
         cert_reqs = 'CERT_REQUIRED' if verify_cert else 'CERT_NONE'
         self._http = urllib3.PoolManager(


### PR DESCRIPTION
My team is upgrading to the latest Mixpanel version, and we noticed the behavior change of `verify_cert` moving to `False` by default.

We would like to use `verify_cert=True`, but I noticed that `Mixpanel.__init__` is disabling urllib3 warnings regardless of the `verify_cert` value. By disabling this warning in urllib3 unguarded in `__init__`, I think the Mixpanel library is effectively disabling this warning for *any* libraries that use urllib3.

This branch changes that so that the warnings will only be disabled if the `verify_cert` value is left in its more insecure default mode of `False`.

Thanks for the consideration!