### PR TITLE
Use requests rather than urllib3

### DIFF
--- a/mixpanel/__init__.py
+++ b/mixpanel/__init__.py
@@ -174,7 +174,6 @@ class Mixpanel(object):
             Calling this method *always* results in a synchronous HTTP request
             to Mixpanel servers, regardless of any custom consumer.
         """
-        sync_consumer = Consumer()
         event = {
             'event': '$create_alias',
             'properties': {
@@ -185,6 +184,8 @@ class Mixpanel(object):
         }
         if meta:
             event.update(meta)
+
+        sync_consumer = Consumer()
         sync_consumer.send('events', json_dumps(event, cls=self._serializer))
 
     def merge(self, api_key, distinct_id1, distinct_id2, meta=None, api_secret=None):

--- a/mixpanel/__init__.py
+++ b/mixpanel/__init__.py
@@ -542,7 +542,7 @@ class Consumer(object):
 
     def __init__(self, events_url=None, people_url=None, import_url=None,
             request_timeout=None, groups_url=None, api_host="api.mixpanel.com",
-            retry_limit=4, retry_backoff_factor=0.25, verify_cert=False):
+            retry_limit=4, retry_backoff_factor=0.25, verify_cert=True):
         # TODO: With next major version, make the above args kwarg-only, and reorder them.
         self._endpoints = {
             'events': events_url or 'https://{}/track'.format(api_host),
@@ -615,11 +615,12 @@ class Consumer(object):
             basic_auth = HTTPBasicAuth(api_secret, '')
 
         try:
-            print("sending w/ requests")
             response = self._session.post(
                 request_url,
                 data=data,
                 auth=basic_auth,
+                timeout=self._request_timeout,
+                verify=self._verify_cert,
             )
         except Exception as e:
             six.raise_from(MixpanelException(e), e)
@@ -669,7 +670,7 @@ class BufferedConsumer(object):
     """
     def __init__(self, max_size=50, events_url=None, people_url=None, import_url=None,
             request_timeout=None, groups_url=None, api_host="api.mixpanel.com",
-            retry_limit=4, retry_backoff_factor=0.25, verify_cert=False):
+            retry_limit=4, retry_backoff_factor=0.25, verify_cert=True):
         self._consumer = Consumer(events_url, people_url, import_url, request_timeout,
             groups_url, api_host, retry_limit, retry_backoff_factor, verify_cert)
         self._buffers = {

--- a/mixpanel/__init__.py
+++ b/mixpanel/__init__.py
@@ -21,10 +21,10 @@ import logging
 import time
 import uuid
 
-import six
-from six.moves import range
 import requests
 from requests.auth import HTTPBasicAuth
+import six
+from six.moves import range
 import urllib3
 
 __version__ = '4.8.4'
@@ -596,19 +596,18 @@ class Consumer(object):
         self._write_request(self._endpoints[endpoint], json_message, api_key, api_secret)
 
     def _write_request(self, request_url, json_message, api_key=None, api_secret=None):
-        data = {
-            'data': json_message,
-            'verbose': 1,
-            'ip': 0,
-        }
-
         if isinstance(api_key, tuple):
             # For compatibility with subclassers, allow the auth details to be
             # packed into the existing api_key param.
             api_key, api_secret = api_key
 
+        params = {
+            'data': json_message,
+            'verbose': 1,
+            'ip': 0,
+        }
         if api_key:
-            data.update({'api_key': api_key})
+            params['api_key'] = api_key
 
         basic_auth = None
         if api_secret is not None:
@@ -617,7 +616,7 @@ class Consumer(object):
         try:
             response = self._session.post(
                 request_url,
-                json=data,
+                json=params,
                 auth=basic_auth,
                 timeout=self._request_timeout,
                 verify=self._verify_cert,

--- a/mixpanel/__init__.py
+++ b/mixpanel/__init__.py
@@ -617,7 +617,7 @@ class Consumer(object):
         try:
             response = self._session.post(
                 request_url,
-                data=data,
+                json=data,
                 auth=basic_auth,
                 timeout=self._request_timeout,
                 verify=self._verify_cert,

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,3 +1,4 @@
 mock==1.3.0
-pytest==4.6.11
+pytest~=4.6
+responses~=0.13.3
 typing; python_version >='3.4' and python_version <'3.5' # To work around CI fail.

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,3 +1,3 @@
 pytest~=4.6
 responses~=0.13.3
-typing; python_version >='3.4' and python_version <'3.5' # To work around CI fail.
+typing; python_version>='3.4' and python_version<'3.5' # To work around CI fail.

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,4 +1,3 @@
-mock==1.3.0
 pytest~=4.6
 responses~=0.13.3
 typing; python_version >='3.4' and python_version <'3.5' # To work around CI fail.

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
     install_requires=[
         'six>=1.9.0',
         'requests>=2.0.0',
+        'urllib3',
     ],
 
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     license='Apache',
     install_requires=[
         'six>=1.9.0',
-        'requests>=2.0.0',
+        'requests>=2.4.2',
         'urllib3',
     ],
 

--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,8 @@ setup(
     author_email='dev@mixpanel.com',
     license='Apache',
     install_requires=[
-        'six >= 1.9.0',
-        'urllib3 >= 1.21.1',
+        'six>=1.9.0',
+        'requests>=2.0.0',
     ],
 
     classifiers=[

--- a/test_mixpanel.py
+++ b/test_mixpanel.py
@@ -583,7 +583,8 @@ class TestFunctional:
         )
 
         self.mp.track('player1', 'button_press', {'size': 'big', 'color': 'blue', '$insert_id': 'xyz1200'})
-        wrapper = json.loads(responses.calls[0].request.body)
+        body = six.ensure_str(responses.calls[0].request.body)
+        wrapper = json.loads(body)
         data = json.loads(wrapper["data"])
         del wrapper["data"]
 
@@ -601,8 +602,8 @@ class TestFunctional:
         )
 
         self.mp.people_set('amq', {'birth month': 'october', 'favorite color': 'purple'})
-
-        wrapper = json.loads(responses.calls[0].request.body)
+        body = six.ensure_str(responses.calls[0].request.body)
+        wrapper = json.loads(body)
         data = json.loads(wrapper["data"])
         del wrapper["data"]
 

--- a/test_mixpanel.py
+++ b/test_mixpanel.py
@@ -1,17 +1,13 @@
 from __future__ import absolute_import, unicode_literals
-import base64
-import contextlib
 import datetime
 import decimal
 import json
 import time
 
-from mock import Mock, patch
 import pytest
 import responses
 import six
 from six.moves import range
-import urllib3
 
 import mixpanel
 
@@ -290,8 +286,12 @@ class TestMixpanel:
     @responses.activate
     def test_alias(self):
         # More complicated since alias() forces a synchronous call.
-        responses.add(responses.POST, 'https://api.mixpanel.com/track',
-            json={"status": 1, "error": None}, status=200)
+        responses.add(
+            responses.POST,
+            'https://api.mixpanel.com/track',
+            json={"status": 1, "error": None},
+            status=200,
+        )
 
         self.mp.alias('ALIAS', 'ORIGINAL ID')
         assert self.consumer.log == []
@@ -299,8 +299,9 @@ class TestMixpanel:
         call = responses.calls[0]
         assert call.request.method == "POST"
         assert call.request.url == "https://api.mixpanel.com/track"
-        posted_dict = json.loads(call.request.body.decode('utf-8'))
-        assert json.loads(posted_dict["data"]) == {"event":"$create_alias","properties":{"alias":"ALIAS","token":"12345","distinct_id":"ORIGINAL ID"}}
+        posted_data = json.loads(call.request.body.decode('utf-8'))
+        print(posted_data)
+        assert json.loads(posted_data["data"]) == {"event":"$create_alias","properties":{"alias":"ALIAS","token":"12345","distinct_id":"ORIGINAL ID"}}
 
     def test_merge(self):
         self.mp.merge('my_good_api_key', 'd1', 'd2')
@@ -450,37 +451,49 @@ class TestConsumer:
     def setup_class(cls):
         cls.consumer = mixpanel.Consumer(request_timeout=30)
 
-    @contextlib.contextmanager
-    def _assertSends(self, expect_url, expect_data, consumer=None):
-        if consumer is None:
-            consumer = self.consumer
-
-        mock_response = Mock()
-        mock_response.data = six.b('{"status": 1, "error": null}')
-        with patch('mixpanel.urllib3.PoolManager.request', return_value=mock_response) as req:
-            yield
-
-            assert req.call_count == 1
-            (call_args, kwargs) = req.call_args
-            (method, url) = call_args
-            assert method == 'POST'
-            assert url == expect_url
-            assert kwargs["fields"] == expect_data
-
+    @responses.activate
     def test_send_events(self):
-        with self._assertSends('https://api.mixpanel.com/track', {"ip": 0, "verbose": 1, "data": '{"foo":"bar"}'}):
-            self.consumer.send('events', '{"foo":"bar"}')
+        responses.add(
+            responses.POST,
+            'https://api.mixpanel.com/track',
+            json={"status": 1, "error": None},
+            status=200,
+            match=[responses.json_params_matcher({"ip": 0, "verbose": 1, "data": '{"foo":"bar"}'})],
+        )
+        self.consumer.send('events', '{"foo":"bar"}')
 
+    @responses.activate
     def test_send_people(self):
-        with self._assertSends('https://api.mixpanel.com/engage', {"ip": 0, "verbose": 1, "data": '{"foo":"bar"}'}):
-            self.consumer.send('people', '{"foo":"bar"}')
+        responses.add(
+            responses.POST,
+            'https://api.mixpanel.com/engage',
+            json={"status": 1, "error": None},
+            status=200,
+            match=[responses.json_params_matcher({"ip": 0, "verbose": 1, "data": '{"foo":"bar"}'})],
+        )
+        self.consumer.send('people', '{"foo":"bar"}')
 
+    @responses.activate
     def test_consumer_override_api_host(self):
-        consumer = mixpanel.Consumer(api_host="api-eu.mixpanel.com")
-        with self._assertSends('https://api-eu.mixpanel.com/track', {"ip": 0, "verbose": 1, "data": '{"foo":"bar"}'}, consumer=consumer):
-            consumer.send('events', '{"foo":"bar"}')
-        with self._assertSends('https://api-eu.mixpanel.com/engage', {"ip": 0, "verbose": 1, "data": '{"foo":"bar"}'}, consumer=consumer):
-            consumer.send('people', '{"foo":"bar"}')
+        consumer = mixpanel.Consumer(api_host="api-zoltan.mixpanel.com")
+
+        responses.add(
+            responses.POST,
+            'https://api-zoltan.mixpanel.com/track',
+            json={"status": 1, "error": None},
+            status=200,
+            match=[responses.json_params_matcher({"ip": 0, "verbose": 1, "data": '{"foo":"bar"}'})],
+        )
+        consumer.send('events', '{"foo":"bar"}')
+
+        responses.add(
+            responses.POST,
+            'https://api-zoltan.mixpanel.com/engage',
+            json={"status": 1, "error": None},
+            status=200,
+            match=[responses.json_params_matcher({"ip": 0, "verbose": 1, "data": '{"foo":"bar"}'})],
+        )
+        consumer.send('people', '{"foo":"bar"}')
 
     def test_unknown_endpoint(self):
         with pytest.raises(mixpanel.MixpanelException):
@@ -521,17 +534,23 @@ class TestBufferedConsumer:
         with pytest.raises(mixpanel.MixpanelException):
             self.consumer.send('unknown', '1')
 
+    @responses.activate
     def test_useful_reraise_in_flush_endpoint(self):
-        error_mock = Mock()
-        error_mock.data = six.b('{"status": 0, "error": "arbitrary error"}')
+        responses.add(
+            responses.POST,
+            'https://api.mixpanel.com/track',
+            json={"status": 0, "error": "arbitrary error"},
+            status=200,
+        )
+
         broken_json = '{broken JSON'
         consumer = mixpanel.BufferedConsumer(2)
-        with patch('mixpanel.urllib3.PoolManager.request', return_value=error_mock):
-            consumer.send('events', broken_json)
-            with pytest.raises(mixpanel.MixpanelException) as excinfo:
-                consumer.flush()
-            assert excinfo.value.message == '[%s]' % broken_json
-            assert excinfo.value.endpoint == 'events'
+        consumer.send('events', broken_json)
+
+        with pytest.raises(mixpanel.MixpanelException) as excinfo:
+            consumer.flush()
+        assert excinfo.value.message == '[%s]' % broken_json
+        assert excinfo.value.endpoint == 'events'
 
     def test_send_remembers_api_key(self):
         self.consumer.send('imports', '"Event"', api_key='MY_API_KEY')
@@ -555,27 +574,39 @@ class TestFunctional:
         cls.mp = mixpanel.Mixpanel(cls.TOKEN)
         cls.mp._now = lambda: 1000
 
-    @contextlib.contextmanager
-    def _assertRequested(self, expect_url, expect_data):
-        res = Mock()
-        res.data = six.b('{"status": 1, "error": null}')
-        with patch('mixpanel.urllib3.PoolManager.request', return_value=res) as req:
-            yield
-
-            assert req.call_count == 1
-            ((method, url,), data) = req.call_args
-            data = data["fields"]["data"]
-            assert method == 'POST'
-            assert url == expect_url
-            payload = json.loads(data)
-            assert payload == expect_data
-
+    @responses.activate
     def test_track_functional(self):
-        expect_data = {'event': 'button_press', 'properties': {'size': 'big', 'color': 'blue', 'mp_lib': 'python', 'token': '12345', 'distinct_id': 'player1', '$lib_version': mixpanel.__version__, 'time': 1000, '$insert_id': 'xyz1200'}}
-        with self._assertRequested('https://api.mixpanel.com/track', expect_data):
-            self.mp.track('player1', 'button_press', {'size': 'big', 'color': 'blue', '$insert_id': 'xyz1200'})
+        responses.add(
+            responses.POST,
+            'https://api.mixpanel.com/track',
+            json={"status": 1, "error": None},
+            status=200,
+        )
 
+        self.mp.track('player1', 'button_press', {'size': 'big', 'color': 'blue', '$insert_id': 'xyz1200'})
+        wrapper = json.loads(responses.calls[0].request.body)
+        data = json.loads(wrapper["data"])
+        del wrapper["data"]
+
+        assert {"ip": 0, "verbose": 1} == wrapper
+        expected_data = {'event': 'button_press', 'properties': {'size': 'big', 'color': 'blue', 'mp_lib': 'python', 'token': '12345', 'distinct_id': 'player1', '$lib_version': mixpanel.__version__, 'time': 1000, '$insert_id': 'xyz1200'}}
+        assert expected_data == data
+
+    @responses.activate
     def test_people_set_functional(self):
-        expect_data = {'$distinct_id': 'amq', '$set': {'birth month': 'october', 'favorite color': 'purple'}, '$time': 1000, '$token': '12345'}
-        with self._assertRequested('https://api.mixpanel.com/engage', expect_data):
-            self.mp.people_set('amq', {'birth month': 'october', 'favorite color': 'purple'})
+        responses.add(
+            responses.POST,
+            'https://api.mixpanel.com/engage',
+            json={"status": 1, "error": None},
+            status=200,
+        )
+
+        self.mp.people_set('amq', {'birth month': 'october', 'favorite color': 'purple'})
+
+        wrapper = json.loads(responses.calls[0].request.body)
+        data = json.loads(wrapper["data"])
+        del wrapper["data"]
+
+        assert {"ip": 0, "verbose": 1} == wrapper
+        expected_data = {'$distinct_id': 'amq', '$set': {'birth month': 'october', 'favorite color': 'purple'}, '$time': 1000, '$token': '12345'}
+        assert expected_data == data

--- a/test_mixpanel.py
+++ b/test_mixpanel.py
@@ -622,11 +622,10 @@ class TestBufferedConsumer:
 
         with pytest.raises(mixpanel.MixpanelException) as excinfo:
             consumer.flush()
-
-        assert len(responses.calls) == 1
-
         assert excinfo.value.message == '[%s]' % broken_json
         assert excinfo.value.endpoint == 'events'
+
+        assert len(responses.calls) == 1
 
     def test_send_remembers_api_key(self):
         self.consumer.send('imports', '"Event"', api_key='MY_API_KEY')

--- a/test_mixpanel.py
+++ b/test_mixpanel.py
@@ -284,24 +284,25 @@ class TestMixpanel:
             }
         )]
 
-    @responses.activate
     def test_alias(self):
         # More complicated since alias() forces a synchronous call.
-        responses.add(
-            responses.POST,
-            'https://api.mixpanel.com/track',
-            json={"status": 1, "error": None},
-            status=200,
-        )
 
-        self.mp.alias('ALIAS', 'ORIGINAL ID')
-        assert self.consumer.log == []
-        assert len(responses.calls) == 1
-        call = responses.calls[0]
-        assert call.request.method == "POST"
-        assert call.request.url == "https://api.mixpanel.com/track"
-        posted_data = dict(urllib.parse.parse_qsl(six.ensure_str(call.request.body)))
-        assert json.loads(posted_data["data"]) == {"event":"$create_alias","properties":{"alias":"ALIAS","token":"12345","distinct_id":"ORIGINAL ID"}}
+        with responses.RequestsMock() as rsps:
+            rsps.add(
+                responses.POST,
+                'https://api.mixpanel.com/track',
+                json={"status": 1, "error": None},
+                status=200,
+            )
+
+            self.mp.alias('ALIAS', 'ORIGINAL ID')
+
+            assert self.consumer.log == []
+            call = rsps.calls[0]
+            assert call.request.method == "POST"
+            assert call.request.url == "https://api.mixpanel.com/track"
+            posted_data = dict(urllib.parse.parse_qsl(six.ensure_str(call.request.body)))
+            assert json.loads(posted_data["data"]) == {"event":"$create_alias","properties":{"alias":"ALIAS","token":"12345","distinct_id":"ORIGINAL ID"}}
 
     def test_merge(self):
         self.mp.merge('my_good_api_key', 'd1', 'd2')
@@ -451,122 +452,114 @@ class TestConsumer:
     def setup_class(cls):
         cls.consumer = mixpanel.Consumer(request_timeout=30)
 
-    @responses.activate
     def test_send_events(self):
-        responses.add(
-            responses.POST,
-            'https://api.mixpanel.com/track',
-            json={"status": 1, "error": None},
-            status=200,
-            match=[responses.urlencoded_params_matcher({"ip": "0", "verbose": "1", "data": '{"foo":"bar"}'})],
-        )
-        self.consumer.send('events', '{"foo":"bar"}')
-        assert len(responses.calls) == 1
+        with responses.RequestsMock() as rsps:
+            rsps.add(
+                responses.POST,
+                'https://api.mixpanel.com/track',
+                json={"status": 1, "error": None},
+                status=200,
+                match=[responses.urlencoded_params_matcher({"ip": "0", "verbose": "1", "data": '{"foo":"bar"}'})],
+            )
+            self.consumer.send('events', '{"foo":"bar"}')
 
-    @responses.activate
     def test_send_people(self):
-        responses.add(
-            responses.POST,
-            'https://api.mixpanel.com/engage',
-            json={"status": 1, "error": None},
-            status=200,
-            match=[responses.urlencoded_params_matcher({"ip": "0", "verbose": "1", "data": '{"foo":"bar"}'})],
-        )
-        self.consumer.send('people', '{"foo":"bar"}')
-        assert len(responses.calls) == 1
+        with responses.RequestsMock() as rsps:
+            rsps.add(
+                responses.POST,
+                'https://api.mixpanel.com/engage',
+                json={"status": 1, "error": None},
+                status=200,
+                match=[responses.urlencoded_params_matcher({"ip": "0", "verbose": "1", "data": '{"foo":"bar"}'})],
+            )
+            self.consumer.send('people', '{"foo":"bar"}')
 
-    @responses.activate
     def test_server_success(self):
-        responses.add(
-            responses.POST,
-            'https://api.mixpanel.com/track',
-            json={"status": 1, "error": None},
-            status=200,
-            match=[responses.urlencoded_params_matcher({"ip": "0", "verbose": "1", "data": '{"foo":"bar"}'})],
-        )
-        self.consumer.send('events', '{"foo":"bar"}')
-        assert len(responses.calls) == 1
+        with responses.RequestsMock() as rsps:
+            rsps.add(
+                responses.POST,
+                'https://api.mixpanel.com/track',
+                json={"status": 1, "error": None},
+                status=200,
+                match=[responses.urlencoded_params_matcher({"ip": "0", "verbose": "1", "data": '{"foo":"bar"}'})],
+            )
+            self.consumer.send('events', '{"foo":"bar"}')
 
-    @responses.activate
     def test_server_invalid_data(self):
-        error_msg = "bad data"
-        responses.add(
-            responses.POST,
-            'https://api.mixpanel.com/track',
-            json={"status": 0, "error": error_msg},
-            status=200,
-            match=[responses.urlencoded_params_matcher({"ip": "0", "verbose": "1", "data": '{INVALID "foo":"bar"}'})],
-        )
+        with responses.RequestsMock() as rsps:
+            error_msg = "bad data"
+            rsps.add(
+                responses.POST,
+                'https://api.mixpanel.com/track',
+                json={"status": 0, "error": error_msg},
+                status=200,
+                match=[responses.urlencoded_params_matcher({"ip": "0", "verbose": "1", "data": '{INVALID "foo":"bar"}'})],
+            )
 
-        with pytest.raises(mixpanel.MixpanelException) as exc:
-            self.consumer.send('events', '{INVALID "foo":"bar"}')
-        assert len(responses.calls) == 1
-        assert error_msg in str(exc)
+            with pytest.raises(mixpanel.MixpanelException) as exc:
+                self.consumer.send('events', '{INVALID "foo":"bar"}')
+            assert error_msg in str(exc)
 
-    @responses.activate
     def test_server_unauthorized(self):
-        responses.add(
-            responses.POST,
-            'https://api.mixpanel.com/track',
-            json={"status": 0, "error": "unauthed"},
-            status=401,
-            match=[responses.urlencoded_params_matcher({"ip": "0", "verbose": "1", "data": '{"foo":"bar"}'})],
-        )
-        with pytest.raises(mixpanel.MixpanelException) as exc:
-            self.consumer.send('events', '{"foo":"bar"}')
-        assert len(responses.calls) == 1
-        assert "unauthed" in str(exc)
+        with responses.RequestsMock() as rsps:
+            rsps.add(
+                responses.POST,
+                'https://api.mixpanel.com/track',
+                json={"status": 0, "error": "unauthed"},
+                status=401,
+                match=[responses.urlencoded_params_matcher({"ip": "0", "verbose": "1", "data": '{"foo":"bar"}'})],
+            )
+            with pytest.raises(mixpanel.MixpanelException) as exc:
+                self.consumer.send('events', '{"foo":"bar"}')
+            assert "unauthed" in str(exc)
 
-    @responses.activate
     def test_server_forbidden(self):
-        responses.add(
-            responses.POST,
-            'https://api.mixpanel.com/track',
-            json={"status": 0, "error": "forbade"},
-            status=403,
-            match=[responses.urlencoded_params_matcher({"ip": "0", "verbose": "1", "data": '{"foo":"bar"}'})],
-        )
-        with pytest.raises(mixpanel.MixpanelException) as exc:
-            self.consumer.send('events', '{"foo":"bar"}')
-        assert len(responses.calls) == 1
-        assert "forbade" in str(exc)
+        with responses.RequestsMock() as rsps:
+            rsps.add(
+                responses.POST,
+                'https://api.mixpanel.com/track',
+                json={"status": 0, "error": "forbade"},
+                status=403,
+                match=[responses.urlencoded_params_matcher({"ip": "0", "verbose": "1", "data": '{"foo":"bar"}'})],
+            )
+            with pytest.raises(mixpanel.MixpanelException) as exc:
+                self.consumer.send('events', '{"foo":"bar"}')
+            assert "forbade" in str(exc)
 
-    @responses.activate
     def test_server_5xx(self):
-        responses.add(
-            responses.POST,
-            'https://api.mixpanel.com/track',
-            body="Internal server error",
-            status=500,
-            match=[responses.json_params_matcher({"ip": 0, "verbose": 1, "data": '{"foo":"bar"}'})],
-        )
-        with pytest.raises(mixpanel.MixpanelException) as exc:
-            self.consumer.send('events', '{"foo":"bar"}')
-        assert len(responses.calls) == 1
+        with responses.RequestsMock() as rsps:
+            rsps.add(
+                responses.POST,
+                'https://api.mixpanel.com/track',
+                body="Internal server error",
+                status=500,
+                match=[responses.urlencoded_params_matcher({"ip": "0", "verbose": "1", "data": '{"foo":"bar"}'})],
+            )
+            with pytest.raises(mixpanel.MixpanelException) as exc:
+                self.consumer.send('events', '{"foo":"bar"}')
 
-    @responses.activate
     def test_consumer_override_api_host(self):
         consumer = mixpanel.Consumer(api_host="api-zoltan.mixpanel.com")
 
-        responses.add(
-            responses.POST,
-            'https://api-zoltan.mixpanel.com/track',
-            json={"status": 1, "error": None},
-            status=200,
-            match=[responses.urlencoded_params_matcher({"ip": "0", "verbose": "1", "data": '{"foo":"bar"}'})],
-        )
-        consumer.send('events', '{"foo":"bar"}')
-        assert len(responses.calls) == 1
+        with responses.RequestsMock() as rsps:
+            rsps.add(
+                responses.POST,
+                'https://api-zoltan.mixpanel.com/track',
+                json={"status": 1, "error": None},
+                status=200,
+                match=[responses.urlencoded_params_matcher({"ip": "0", "verbose": "1", "data": '{"foo":"bar"}'})],
+            )
+            consumer.send('events', '{"foo":"bar"}')
 
-        responses.add(
-            responses.POST,
-            'https://api-zoltan.mixpanel.com/engage',
-            json={"status": 1, "error": None},
-            status=200,
-            match=[responses.urlencoded_params_matcher({"ip": "0", "verbose": "1", "data": '{"foo":"bar"}'})],
-        )
-        consumer.send('people', '{"foo":"bar"}')
-        assert len(responses.calls) == 2
+        with responses.RequestsMock() as rsps:
+            rsps.add(
+                responses.POST,
+                'https://api-zoltan.mixpanel.com/engage',
+                json={"status": 1, "error": None},
+                status=200,
+                match=[responses.urlencoded_params_matcher({"ip": "0", "verbose": "1", "data": '{"foo":"bar"}'})],
+            )
+            consumer.send('people', '{"foo":"bar"}')
 
     def test_unknown_endpoint(self):
         with pytest.raises(mixpanel.MixpanelException):
@@ -607,25 +600,23 @@ class TestBufferedConsumer:
         with pytest.raises(mixpanel.MixpanelException):
             self.consumer.send('unknown', '1')
 
-    @responses.activate
     def test_useful_reraise_in_flush_endpoint(self):
-        responses.add(
-            responses.POST,
-            'https://api.mixpanel.com/track',
-            json={"status": 0, "error": "arbitrary error"},
-            status=200,
-        )
+        with responses.RequestsMock() as rsps:
+            rsps.add(
+                responses.POST,
+                'https://api.mixpanel.com/track',
+                json={"status": 0, "error": "arbitrary error"},
+                status=200,
+            )
 
-        broken_json = '{broken JSON'
-        consumer = mixpanel.BufferedConsumer(2)
-        consumer.send('events', broken_json)
+            broken_json = '{broken JSON'
+            consumer = mixpanel.BufferedConsumer(2)
+            consumer.send('events', broken_json)
 
-        with pytest.raises(mixpanel.MixpanelException) as excinfo:
-            consumer.flush()
-        assert excinfo.value.message == '[%s]' % broken_json
-        assert excinfo.value.endpoint == 'events'
-
-        assert len(responses.calls) == 1
+            with pytest.raises(mixpanel.MixpanelException) as excinfo:
+                consumer.flush()
+            assert excinfo.value.message == '[%s]' % broken_json
+            assert excinfo.value.endpoint == 'events'
 
     def test_send_remembers_api_key(self):
         self.consumer.send('imports', '"Event"', api_key='MY_API_KEY')
@@ -649,43 +640,41 @@ class TestFunctional:
         cls.mp = mixpanel.Mixpanel(cls.TOKEN)
         cls.mp._now = lambda: 1000
 
-    @responses.activate
     def test_track_functional(self):
-        responses.add(
-            responses.POST,
-            'https://api.mixpanel.com/track',
-            json={"status": 1, "error": None},
-            status=200,
-        )
+        with responses.RequestsMock() as rsps:
+            rsps.add(
+                responses.POST,
+                'https://api.mixpanel.com/track',
+                json={"status": 1, "error": None},
+                status=200,
+            )
 
-        self.mp.track('player1', 'button_press', {'size': 'big', 'color': 'blue', '$insert_id': 'xyz1200'})
+            self.mp.track('player1', 'button_press', {'size': 'big', 'color': 'blue', '$insert_id': 'xyz1200'})
 
-        assert len(responses.calls) == 1
-        body = six.ensure_str(responses.calls[0].request.body)
-        wrapper = dict(urllib.parse.parse_qsl(body))
-        data = json.loads(wrapper["data"])
-        del wrapper["data"]
+            body = six.ensure_str(rsps.calls[0].request.body)
+            wrapper = dict(urllib.parse.parse_qsl(body))
+            data = json.loads(wrapper["data"])
+            del wrapper["data"]
 
-        assert {"ip": "0", "verbose": "1"} == wrapper
-        expected_data = {'event': 'button_press', 'properties': {'size': 'big', 'color': 'blue', 'mp_lib': 'python', 'token': '12345', 'distinct_id': 'player1', '$lib_version': mixpanel.__version__, 'time': 1000, '$insert_id': 'xyz1200'}}
-        assert expected_data == data
+            assert {"ip": "0", "verbose": "1"} == wrapper
+            expected_data = {'event': 'button_press', 'properties': {'size': 'big', 'color': 'blue', 'mp_lib': 'python', 'token': '12345', 'distinct_id': 'player1', '$lib_version': mixpanel.__version__, 'time': 1000, '$insert_id': 'xyz1200'}}
+            assert expected_data == data
 
-    @responses.activate
     def test_people_set_functional(self):
-        responses.add(
-            responses.POST,
-            'https://api.mixpanel.com/engage',
-            json={"status": 1, "error": None},
-            status=200,
-        )
+        with responses.RequestsMock() as rsps:
+            rsps.add(
+                responses.POST,
+                'https://api.mixpanel.com/engage',
+                json={"status": 1, "error": None},
+                status=200,
+            )
 
-        self.mp.people_set('amq', {'birth month': 'october', 'favorite color': 'purple'})
-        assert len(responses.calls) == 1
-        body = six.ensure_str(responses.calls[0].request.body)
-        wrapper = dict(urllib.parse.parse_qsl(body))
-        data = json.loads(wrapper["data"])
-        del wrapper["data"]
+            self.mp.people_set('amq', {'birth month': 'october', 'favorite color': 'purple'})
+            body = six.ensure_str(rsps.calls[0].request.body)
+            wrapper = dict(urllib.parse.parse_qsl(body))
+            data = json.loads(wrapper["data"])
+            del wrapper["data"]
 
-        assert {"ip": "0", "verbose": "1"} == wrapper
-        expected_data = {'$distinct_id': 'amq', '$set': {'birth month': 'october', 'favorite color': 'purple'}, '$time': 1000, '$token': '12345'}
-        assert expected_data == data
+            assert {"ip": "0", "verbose": "1"} == wrapper
+            expected_data = {'$distinct_id': 'amq', '$set': {'birth month': 'october', 'favorite color': 'purple'}, '$time': 1000, '$token': '12345'}
+            assert expected_data == data

--- a/test_mixpanel.py
+++ b/test_mixpanel.py
@@ -299,8 +299,7 @@ class TestMixpanel:
         call = responses.calls[0]
         assert call.request.method == "POST"
         assert call.request.url == "https://api.mixpanel.com/track"
-        posted_data = json.loads(call.request.body.decode('utf-8'))
-        print(posted_data)
+        posted_data = json.loads(six.ensure_str(call.request.body))
         assert json.loads(posted_data["data"]) == {"event":"$create_alias","properties":{"alias":"ALIAS","token":"12345","distinct_id":"ORIGINAL ID"}}
 
     def test_merge(self):


### PR DESCRIPTION
I have been doing some research around the cert verification topic, and I came to the following points:
1. mixpanel-python should strive to work without certificate hassles as much as possible. It is used in a wide variety of environments/servers/personal computers/diff't Python versions/etc.
2. I asked in the urllib3 discord channel if:
   1. if I should begin to depend on `urllib3[secure]` rather than plain old `urllib3`. The answer was "no," as that extra option is being deprecated, and will do kinda "the wrong thing" w/r/t pyOpenSSL.
   2. if I should apply this fix from `requests`  to my project: https://github.com/psf/requests/pull/5443. The answer was "yes," that it would probably help.
   3. if I should explicitly depend on `certifi`. (Included in `urllib3[secure]`, but we aren't using that.) The answer was "yes." It will remove a lot of variability in root certs in the wild. (And indeed make having a local cert store optional.)



> The current recommendation is that on modern Python versions (2.7.9+/3.4+) you're better off using the builtin Python ssl module because there's native SNI support. So that means not installing the [secure] extra and not injecting pyOpenSSL on those versions.
> It's unfortunate that the old way of doing things was the default for a lot longer than it had to be and that the extra is named "secure", we're paying the distributed tech debt price by removing it as the default and trying to document this better.
> Let me know if you have more questions :) I think the approach in the PR you mentioned is a good one but might be even better to force users to at least install Python 2.7.9+. Versions before that are really really old and insecure.


So I began to add items ii and iii to mixpanel-python. But then realized `requests` does both of those OOTB, and does a bunch of other sniffing around certifi/default certs/unzipping cert bundles/overriding certifi/etc. So to support point 1, I am just going to use `requests`.

