### PR TITLE
Be able to add his proper sync consumer in mixpanel initializer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@ docs/_build
 .idea/
 .cache/
 .DS_Store
-.env

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ docs/_build
 .idea/
 .cache/
 .DS_Store
+.env

--- a/mixpanel/__init__.py
+++ b/mixpanel/__init__.py
@@ -66,9 +66,10 @@ class Mixpanel(object):
         self._token = token
         self._consumer = consumer or Consumer()
 
-        self._sync_consumer = sync_consumer or Consumer()
-        # if getattr(self._sync_consumer, "flush"):
-        #     raise Exception("sync_consumer must be Consumer instance")
+        if hasattr(self._consumer, "flush"):
+            self._sync_consumer = sync_consumer or Consumer()
+        else:
+            self._sync_consumer = self._consumer
 
         self._serializer = serializer
 

--- a/mixpanel/__init__.py
+++ b/mixpanel/__init__.py
@@ -62,9 +62,14 @@ class Mixpanel(object):
         The *serializer* parameter.
     """
 
-    def __init__(self, token, consumer=None, serializer=DatetimeSerializer):
+    def __init__(self, token, consumer=None, serializer=DatetimeSerializer, sync_consumer=None):
         self._token = token
         self._consumer = consumer or Consumer()
+
+        self._sync_consumer = sync_consumer or Consumer()
+        # if getattr(self._sync_consumer, "flush"):
+        #     raise Exception("sync_consumer must be Consumer instance")
+
         self._serializer = serializer
 
     def _now(self):
@@ -185,8 +190,7 @@ class Mixpanel(object):
         if meta:
             event.update(meta)
 
-        sync_consumer = Consumer()
-        sync_consumer.send('events', json_dumps(event, cls=self._serializer))
+        self._sync_consumer.send('events', json_dumps(event, cls=self._serializer))
 
     def merge(self, api_key, distinct_id1, distinct_id2, meta=None, api_secret=None):
         """

--- a/test_mixpanel.py
+++ b/test_mixpanel.py
@@ -9,6 +9,7 @@ import responses
 import six
 from six.moves import range, urllib
 
+
 import mixpanel
 
 
@@ -85,8 +86,8 @@ class TestMixpanelTracking(TestMixpanelBase):
     def test_import_data(self):
         timestamp = time.time()
         self.mp.import_data('MY_API_KEY', 'ID', 'button press', timestamp,
-                            {'size': 'big', 'color': 'blue', '$insert_id': 'abc123'},
-                            api_secret='MY_SECRET')
+            {'size': 'big', 'color': 'blue', '$insert_id': 'abc123'},
+            api_secret='MY_SECRET')
         assert self.consumer.log == [(
             'imports', {
                 'event': 'button press',
@@ -322,7 +323,12 @@ class TestMixpanelIdentity(TestMixpanelBase):
             self.mp.alias('ALIAS', 'ORIGINAL ID')
 
             assert self.mp._consumer == self.mp._sync_consumer
-            assert self.consumer.log == [('events', {'event': '$create_alias', 'properties': {'distinct_id': 'ORIGINAL ID', 'alias': 'ALIAS', 'token': '12345'}})]
+            assert self.consumer.log == [
+                ('events', {
+                    'event': '$create_alias',
+                    'properties': {'distinct_id': 'ORIGINAL ID', 'alias': 'ALIAS', 'token': '12345'}
+                })
+            ]
 
     def test_merge(self):
         self.mp.merge('my_good_api_key', 'd1', 'd2')
@@ -499,8 +505,7 @@ class TestConsumer:
                 'https://api.mixpanel.com/track',
                 json={"status": 0, "error": error_msg},
                 status=200,
-                match=[
-                    responses.urlencoded_params_matcher({"ip": "0", "verbose": "1", "data": '{INVALID "foo":"bar"}'})],
+                match=[responses.urlencoded_params_matcher({"ip": "0", "verbose": "1", "data": '{INVALID "foo":"bar"}'})],
             )
 
             with pytest.raises(mixpanel.MixpanelException) as exc:
@@ -638,6 +643,8 @@ class TestBufferedConsumer:
         assert self.log == [('imports', ['Event'], (None, 'ZZZZZZ'))]
 
 
+
+
 class TestFunctional:
     @classmethod
     def setup_class(cls):
@@ -662,10 +669,7 @@ class TestFunctional:
             del wrapper["data"]
 
             assert {"ip": "0", "verbose": "1"} == wrapper
-            expected_data = {'event': 'button_press',
-                             'properties': {'size': 'big', 'color': 'blue', 'mp_lib': 'python', 'token': '12345',
-                                            'distinct_id': 'player1', '$lib_version': mixpanel.__version__,
-                                            'time': 1000, '$insert_id': 'xyz1200'}}
+            expected_data = {'event': 'button_press', 'properties': {'size': 'big', 'color': 'blue', 'mp_lib': 'python', 'token': '12345', 'distinct_id': 'player1', '$lib_version': mixpanel.__version__, 'time': 1000, '$insert_id': 'xyz1200'}}
             assert expected_data == data
 
     def test_people_set_functional(self):
@@ -684,6 +688,5 @@ class TestFunctional:
             del wrapper["data"]
 
             assert {"ip": "0", "verbose": "1"} == wrapper
-            expected_data = {'$distinct_id': 'amq', '$set': {'birth month': 'october', 'favorite color': 'purple'},
-                             '$time': 1000, '$token': '12345'}
+            expected_data = {'$distinct_id': 'amq', '$set': {'birth month': 'october', 'favorite color': 'purple'}, '$time': 1000, '$token': '12345'}
             assert expected_data == data


### PR DESCRIPTION
mixpanel.alias method force using sync consumer and initialize one without take in account any custom configuration.
I propose add sync_consumer parameter to mixpanel initializer according to be able to add sync consumer in case of the first given is buffered.