### PR TITLE
Fix connection reset error on long sessions

### DIFF
--- a/mixpanel/__init__.py
+++ b/mixpanel/__init__.py
@@ -572,7 +572,7 @@ class Consumer(object):
         )
 
         self._session = requests.Session()
-        self._session.mount('http', adapter)
+        self._session.mount('https://', adapter)
 
     def send(self, endpoint, json_message, api_key=None, api_secret=None):
         """Immediately record an event or a profile update.


### PR DESCRIPTION
Fix [issue](https://github.com/mixpanel/mixpanel-python/issues/104) of connection reset error.

HTTPAdatper created that allows retrying POST requests is mounted onto requests.Session using the 'http' prefix. This prefix is always superseded by already existing 'https://' which re-raises on POST and fails the request.