### PR TITLE
Implement initial feature flag support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,5 +29,4 @@ jobs:
       uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574 # v5.4.0
       with:
         flags: mixpanel-python
-        files: coverage/lcov.info
         disable_search: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,8 +25,8 @@ jobs:
     - name: Run tests 
       run: |
         pytest --cov --cov-branch --cov-report=xml
-    - name: Upload coverage reports to Codecov with GitHub Action
-      uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574 # v5.4.0
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v5
       with:
-        flags: mixpanel-python
-        disable_search: true
+        token: ${{ secrets.CODECOV_TOKEN }}
+        slug: mixpanel/mixpanel-python

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,4 +24,4 @@ jobs:
         pip install -e .[test]
     - name: Test with pytest
       run: |
-        pytest test_mixpanel.py
+        pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,12 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -e .[test]
-    - name: Test with pytest
+    - name: Run tests 
       run: |
-        pytest
+        pytest --cov --cov-branch --cov-report=xml
+    - name: Upload coverage reports to Codecov with GitHub Action
+      uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574 # v5.4.0
+      with:
+        flags: mixpanel-python
+        files: coverage/lcov.info
+        disable_search: true

--- a/BUILD.rst
+++ b/BUILD.rst
@@ -15,6 +15,11 @@ Run tests::
 
   python -m tox - runs all tests against all configured environments in the pyproject.toml
 
+Run tests under code coverage::
+  python -m coverage run -m pytest
+  python -m coverage report -m
+  python -m coverage html
+
 Publish to PyPI::
 
   python -m build

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,4 @@
-v5.0.0-rc1
+v5.0.0b1
 * Added initial feature flagging support
 
 v4.11.1

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,9 @@
 v5.0.0-rc1
 * Added initial feature flagging support
 
+v4.11.1
+* Loosen requirements for `requests` lib to >=2.4.2 to keep compatible with 2.10
+
 v4.11.0
 * Set minimum supported python version to 3.9, deprecating support for end-of-life versions of python
 * Convert setup.py to pyproject.toml

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,5 @@
-v4.11.1
-* Loosen requirements for `requests` lib to >=2.4.2 to keep compatible with 2.10
+v5.0.0-rc1
+* Added initial feature flagging support
 
 v4.11.0
 * Set minimum supported python version to 3.9, deprecating support for end-of-life versions of python

--- a/demo/local_flags.py
+++ b/demo/local_flags.py
@@ -1,0 +1,32 @@
+import os
+import asyncio
+import mixpanel
+import logging
+
+logging.basicConfig(level=logging.INFO)
+
+# Configure your project token, the feature flag  to test, and user context to evaluate.
+PROJECT_TOKEN = ""
+FLAG_KEY = "sample-flag"
+FLAG_FALLBACK_VARIANT = "control"
+USER_CONTEXT = { "distinct_id": "sample-distinct-id" }
+
+# If False, the flag definitions are fetched just once on SDK initialization. Otherwise, will poll
+SHOULD_POLL_CONTINOUSLY = False
+POLLING_INTERVAL_IN_SECONDS = 90
+
+# Use the correct data residency endpoint for your project.
+API_HOST = "api-eu.mixpanel.com"
+
+async def main():
+    mp = mixpanel.Mixpanel(PROJECT_TOKEN)
+    local_config = mixpanel.LocalFlagsConfig(api_host=API_HOST, enablePolling=SHOULD_POLL_CONTINOUSLY, pollingIntervalInSeconds=POLLING_INTERVAL_IN_SECONDS)
+
+    async with mp.getLocalFlagsProvider(local_config) as local_flags_provider:
+        await local_flags_provider.start_polling_for_definitions()
+
+        variant_value = local_flags_provider.get_variant_value(FLAG_KEY, FLAG_FALLBACK_VARIANT, USER_CONTEXT)
+        print(f"Variant value: {variant_value}")
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/demo/local_flags.py
+++ b/demo/local_flags.py
@@ -6,7 +6,7 @@ import logging
 logging.basicConfig(level=logging.INFO)
 
 # Configure your project token, the feature flag  to test, and user context to evaluate.
-PROJECT_TOKEN = ""
+PROJECT_TOKEN = "044781e247eabd8e9b73fad8a8c093d2"
 FLAG_KEY = "sample-flag"
 FLAG_FALLBACK_VARIANT = "control"
 USER_CONTEXT = { "distinct_id": "sample-distinct-id" }
@@ -20,7 +20,7 @@ API_HOST = "api-eu.mixpanel.com"
 
 async def main():
     mp = mixpanel.Mixpanel(PROJECT_TOKEN)
-    local_config = mixpanel.LocalFlagsConfig(api_host=API_HOST, enablePolling=SHOULD_POLL_CONTINOUSLY, pollingIntervalInSeconds=POLLING_INTERVAL_IN_SECONDS)
+    local_config = mixpanel.LocalFlagsConfig(api_host=API_HOST, enable_polling=SHOULD_POLL_CONTINOUSLY, polling_interval_in_seconds=POLLING_INTERVAL_IN_SECONDS)
 
     async with mp.get_local_flags_provider(local_config) as local_flags_provider:
         await local_flags_provider.astart_polling_for_definitions()

--- a/demo/local_flags.py
+++ b/demo/local_flags.py
@@ -22,8 +22,8 @@ async def main():
     mp = mixpanel.Mixpanel(PROJECT_TOKEN)
     local_config = mixpanel.LocalFlagsConfig(api_host=API_HOST, enablePolling=SHOULD_POLL_CONTINOUSLY, pollingIntervalInSeconds=POLLING_INTERVAL_IN_SECONDS)
 
-    async with mp.getLocalFlagsProvider(local_config) as local_flags_provider:
-        await local_flags_provider.start_polling_for_definitions()
+    async with mp.get_local_flags_provider(local_config) as local_flags_provider:
+        await local_flags_provider.astart_polling_for_definitions()
 
         variant_value = local_flags_provider.get_variant_value(FLAG_KEY, FLAG_FALLBACK_VARIANT, USER_CONTEXT)
         print(f"Variant value: {variant_value}")

--- a/demo/local_flags.py
+++ b/demo/local_flags.py
@@ -6,7 +6,7 @@ import logging
 logging.basicConfig(level=logging.INFO)
 
 # Configure your project token, the feature flag  to test, and user context to evaluate.
-PROJECT_TOKEN = "044781e247eabd8e9b73fad8a8c093d2"
+PROJECT_TOKEN = ""
 FLAG_KEY = "sample-flag"
 FLAG_FALLBACK_VARIANT = "control"
 USER_CONTEXT = { "distinct_id": "sample-distinct-id" }
@@ -19,13 +19,12 @@ POLLING_INTERVAL_IN_SECONDS = 90
 API_HOST = "api-eu.mixpanel.com"
 
 async def main():
-    mp = mixpanel.Mixpanel(PROJECT_TOKEN)
     local_config = mixpanel.LocalFlagsConfig(api_host=API_HOST, enable_polling=SHOULD_POLL_CONTINOUSLY, polling_interval_in_seconds=POLLING_INTERVAL_IN_SECONDS)
 
-    async with mp.get_local_flags_provider(local_config) as local_flags_provider:
-        await local_flags_provider.astart_polling_for_definitions()
-
-        variant_value = local_flags_provider.get_variant_value(FLAG_KEY, FLAG_FALLBACK_VARIANT, USER_CONTEXT)
+    # Optionally use mixpanel client as a context manager, that will ensure shutdown of resources used by feature flagging
+    async with mixpanel.Mixpanel(PROJECT_TOKEN, local_flags_config=local_config) as mp:
+        await mp.local_flags.astart_polling_for_definitions()
+        variant_value = mp.local_flags.get_variant_value(FLAG_KEY, FLAG_FALLBACK_VARIANT, USER_CONTEXT)
         print(f"Variant value: {variant_value}")
 
 if __name__ == '__main__':

--- a/demo/remote_flags.py
+++ b/demo/remote_flags.py
@@ -15,21 +15,21 @@ API_HOST = "api-eu.mixpanel.com"
 
 DEMO_ASYNC = True
 
-async def async_demo(remote_config):
-    async with mp.get_remote_flags_provider(remote_config) as remote_flags_provider:
-        variant_value = await remote_flags_provider.aget_variant_value(FLAG_KEY, FLAG_FALLBACK_VARIANT, USER_CONTEXT)
+async def async_demo():
+    remote_config = mixpanel.RemoteFlagsConfig(api_host=API_HOST)
+    # Optionally use mixpanel client as a context manager, that will ensure shutdown of resources used by feature flagging
+    async with mixpanel.Mixpanel(PROJECT_TOKEN, remote_flags_config=remote_config) as mp:
+        variant_value = await mp.remote_flags.aget_variant_value(FLAG_KEY, FLAG_FALLBACK_VARIANT, USER_CONTEXT)
         print(f"Variant value: {variant_value}")
 
-def sync_demo(remote_config):
-    with mp.get_remote_flags_provider(remote_config) as remote_flags_provider:
-        variant_value = remote_flags_provider.get_variant_value(FLAG_KEY, FLAG_FALLBACK_VARIANT, USER_CONTEXT)
+def sync_demo():
+    remote_config = mixpanel.RemoteFlagsConfig(api_host=API_HOST)
+    with mixpanel.Mixpanel(PROJECT_TOKEN, remote_flags_config=remote_config) as mp:
+        variant_value = mp.remote_flags.get_variant_value(FLAG_KEY, FLAG_FALLBACK_VARIANT, USER_CONTEXT)
         print(f"Variant value: {variant_value}")
 
 if __name__ == '__main__':
-    mp = mixpanel.Mixpanel(PROJECT_TOKEN)
-    remote_config = mixpanel.RemoteFlagsConfig(api_host=API_HOST)
-
     if DEMO_ASYNC:
-        asyncio.run(async_demo(remote_config))
+        asyncio.run(async_demo())
     else:
-        sync_demo(remote_config)
+        sync_demo()

--- a/demo/remote_flags.py
+++ b/demo/remote_flags.py
@@ -1,0 +1,35 @@
+import asyncio
+import mixpanel
+import logging
+
+logging.basicConfig(level=logging.INFO)
+
+# Configure your project token, the feature flag  to test, and user context to evaluate.
+PROJECT_TOKEN = ""
+FLAG_KEY = "sample-flag"
+FLAG_FALLBACK_VARIANT = "control"
+USER_CONTEXT = { "distinct_id": "sample-distinct-id" }
+
+# Use the correct data residency endpoint for your project.
+API_HOST = "api-eu.mixpanel.com"
+
+DEMO_ASYNC = True
+
+async def async_demo(remote_config):
+    async with mp.getRemoteFlagsProvider(remote_config) as remote_flags_provider:
+        variant_value = await remote_flags_provider.get_variant_value(FLAG_KEY, FLAG_FALLBACK_VARIANT, USER_CONTEXT)
+        print(f"Variant value: {variant_value}")
+
+def sync_demo(remote_config):
+    with mp.getRemoteFlagsProvider(remote_config) as remote_flags_provider:
+        variant_value = remote_flags_provider.get_variant_value_sync(FLAG_KEY, FLAG_FALLBACK_VARIANT, USER_CONTEXT)
+        print(f"Variant value: {variant_value}")
+
+if __name__ == '__main__':
+    mp = mixpanel.Mixpanel(PROJECT_TOKEN)
+    remote_config = mixpanel.RemoteFlagsConfig(api_host=API_HOST)
+
+    if DEMO_ASYNC:
+        asyncio.run(async_demo(remote_config))
+    else:
+        sync_demo(remote_config)

--- a/demo/remote_flags.py
+++ b/demo/remote_flags.py
@@ -4,7 +4,7 @@ import logging
 
 logging.basicConfig(level=logging.INFO)
 
-# Configure your project token, the feature flag  to test, and user context to evaluate.
+# Configure your project token, the feature flag to test, and user context to evaluate.
 PROJECT_TOKEN = ""
 FLAG_KEY = "sample-flag"
 FLAG_FALLBACK_VARIANT = "control"

--- a/demo/remote_flags.py
+++ b/demo/remote_flags.py
@@ -17,12 +17,12 @@ DEMO_ASYNC = True
 
 async def async_demo(remote_config):
     async with mp.get_remote_flags_provider(remote_config) as remote_flags_provider:
-        variant_value = await remote_flags_provider.get_variant_value(FLAG_KEY, FLAG_FALLBACK_VARIANT, USER_CONTEXT)
+        variant_value = await remote_flags_provider.aget_variant_value(FLAG_KEY, FLAG_FALLBACK_VARIANT, USER_CONTEXT)
         print(f"Variant value: {variant_value}")
 
 def sync_demo(remote_config):
     with mp.get_remote_flags_provider(remote_config) as remote_flags_provider:
-        variant_value = remote_flags_provider.get_variant_value_sync(FLAG_KEY, FLAG_FALLBACK_VARIANT, USER_CONTEXT)
+        variant_value = remote_flags_provider.get_variant_value(FLAG_KEY, FLAG_FALLBACK_VARIANT, USER_CONTEXT)
         print(f"Variant value: {variant_value}")
 
 if __name__ == '__main__':

--- a/demo/remote_flags.py
+++ b/demo/remote_flags.py
@@ -16,12 +16,12 @@ API_HOST = "api-eu.mixpanel.com"
 DEMO_ASYNC = True
 
 async def async_demo(remote_config):
-    async with mp.getRemoteFlagsProvider(remote_config) as remote_flags_provider:
+    async with mp.get_remote_flags_provider(remote_config) as remote_flags_provider:
         variant_value = await remote_flags_provider.get_variant_value(FLAG_KEY, FLAG_FALLBACK_VARIANT, USER_CONTEXT)
         print(f"Variant value: {variant_value}")
 
 def sync_demo(remote_config):
-    with mp.getRemoteFlagsProvider(remote_config) as remote_flags_provider:
+    with mp.get_remote_flags_provider(remote_config) as remote_flags_provider:
         variant_value = remote_flags_provider.get_variant_value_sync(FLAG_KEY, FLAG_FALLBACK_VARIANT, USER_CONTEXT)
         print(f"Variant value: {variant_value}")
 

--- a/mixpanel/__init__.py
+++ b/mixpanel/__init__.py
@@ -80,7 +80,7 @@ class Mixpanel(object):
         :param Callable tracker: Delegate used to track exposure events 
         :return: LocalFeatureFlagsProvider instance
         """
-        return LocalFeatureFlagsProvider(self._token, config, self.track)
+        return LocalFeatureFlagsProvider(self._token, config, __version__, self.track)
 
     def get_remote_flags_provider(self, config: RemoteFlagsConfig) -> RemoteFeatureFlagsProvider:
         """Create and return a remote feature flags provider.
@@ -90,7 +90,7 @@ class Mixpanel(object):
         :param Callable tracker: Delegate used to track exposure events 
         :return: RemoteFeatureFlagsProvider instance
         """
-        return RemoteFeatureFlagsProvider(self._token, config, self.track)
+        return RemoteFeatureFlagsProvider(self._token, config, __version__, self.track)
 
 
     def track(self, distinct_id, event_name, properties=None, meta=None):

--- a/mixpanel/__init__.py
+++ b/mixpanel/__init__.py
@@ -87,7 +87,7 @@ class Mixpanel():
     def local_flags(self) -> LocalFeatureFlagsProvider:
         """Get the local flags provider if configured for it"""
         if self._local_flags_provider is None:
-            raise ValueError("No local flags provider initialized. Pass local_flags_config to constructor.")
+            raise MixpanelException("No local flags provider initialized. Pass local_flags_config to constructor.")
         return self._local_flags_provider
 
     @property

--- a/mixpanel/__init__.py
+++ b/mixpanel/__init__.py
@@ -75,7 +75,9 @@ class Mixpanel(object):
     def getLocalFlagsProvider(self, config: LocalFlagsConfig) -> LocalFeatureFlagsProvider:
         """Create and return a local feature flags provider.
 
+        :param str token: The project token
         :param LocalFlagsConfig config: Configuration for the local flags provider
+        :param Callable tracker: Delegate used to track exposure events 
         :return: LocalFeatureFlagsProvider instance
         """
         return LocalFeatureFlagsProvider(self._token, config, self.track)
@@ -83,7 +85,9 @@ class Mixpanel(object):
     def getRemoteFlagsProvider(self, config: RemoteFlagsConfig) -> RemoteFeatureFlagsProvider:
         """Create and return a remote feature flags provider.
 
+        :param str token: The project token
         :param RemoteFlagsConfig config: Configuration for the remote flags provider
+        :param Callable tracker: Delegate used to track exposure events 
         :return: RemoteFeatureFlagsProvider instance
         """
         return RemoteFeatureFlagsProvider(self._token, config, self.track)

--- a/mixpanel/__init__.py
+++ b/mixpanel/__init__.py
@@ -72,7 +72,7 @@ class Mixpanel(object):
     def _make_insert_id(self):
         return uuid.uuid4().hex
 
-    def getLocalFlagsProvider(self, config: LocalFlagsConfig) -> LocalFeatureFlagsProvider:
+    def get_local_flags_provider(self, config: LocalFlagsConfig) -> LocalFeatureFlagsProvider:
         """Create and return a local feature flags provider.
 
         :param str token: The project token
@@ -82,7 +82,7 @@ class Mixpanel(object):
         """
         return LocalFeatureFlagsProvider(self._token, config, self.track)
 
-    def getRemoteFlagsProvider(self, config: RemoteFlagsConfig) -> RemoteFeatureFlagsProvider:
+    def get_remote_flags_provider(self, config: RemoteFlagsConfig) -> RemoteFeatureFlagsProvider:
         """Create and return a remote feature flags provider.
 
         :param str token: The project token

--- a/mixpanel/__init__.py
+++ b/mixpanel/__init__.py
@@ -24,11 +24,13 @@ import requests
 from requests.auth import HTTPBasicAuth
 import urllib3
 
-__version__ = '4.11.1'
-VERSION = __version__  # TODO: remove when bumping major version.
+from .flags.local_feature_flags import LocalFeatureFlagsProvider
+from .flags.remote_feature_flags import RemoteFeatureFlagsProvider
+from .flags.types import LocalFlagsConfig, RemoteFlagsConfig
+
+__version__ = '5.0.0-rc1'
 
 logger = logging.getLogger(__name__)
-
 
 class DatetimeSerializer(json.JSONEncoder):
     def default(self, obj):
@@ -69,6 +71,23 @@ class Mixpanel(object):
 
     def _make_insert_id(self):
         return uuid.uuid4().hex
+
+    def getLocalFlagsProvider(self, config: LocalFlagsConfig) -> LocalFeatureFlagsProvider:
+        """Create and return a local feature flags provider.
+
+        :param LocalFlagsConfig config: Configuration for the local flags provider
+        :return: LocalFeatureFlagsProvider instance
+        """
+        return LocalFeatureFlagsProvider(self._token, config, self.track)
+
+    def getRemoteFlagsProvider(self, config: RemoteFlagsConfig) -> RemoteFeatureFlagsProvider:
+        """Create and return a remote feature flags provider.
+
+        :param RemoteFlagsConfig config: Configuration for the remote flags provider
+        :return: RemoteFeatureFlagsProvider instance
+        """
+        return RemoteFeatureFlagsProvider(self._token, config, self.track)
+
 
     def track(self, distinct_id, event_name, properties=None, meta=None):
         """Record an event.

--- a/mixpanel/flags/local_feature_flags.py
+++ b/mixpanel/flags/local_feature_flags.py
@@ -1,0 +1,210 @@
+import httpx
+import logging
+import asyncio
+import time
+from datetime import datetime, timedelta
+from typing import Dict, Any, Callable, Optional
+from .types import ExperimentationFlag, ExperimentationFlags, SelectedVariant, LocalFlagsConfig, Rollout
+from .utils import REQUEST_HEADERS, normalized_hash, track_exposure_event
+
+logger = logging.getLogger(__name__)
+logging.getLogger("httpx").setLevel(logging.ERROR)
+
+class LocalFeatureFlagsProvider:
+    FLAGS_DEFINITIONS_URL_PATH = "/flags/definitions"
+
+    def __init__(self, token: str, config: LocalFlagsConfig, tracker: Callable) -> None:
+        self._token: str = token
+        self._config: LocalFlagsConfig = config
+        self._tracker: Callable = tracker
+
+        self._flag_definitions: Dict[str, ExperimentationFlag] = dict()
+
+        httpx_client_parameters = {
+            "base_url": f"https://{config.api_host}",
+            "headers": REQUEST_HEADERS,
+            "auth": httpx.BasicAuth(token, ""),
+            "timeout": httpx.Timeout(config.requestTimeoutInSeconds),
+        }
+
+        self.async_client: httpx.AsyncClient = httpx.AsyncClient(**httpx_client_parameters)
+        self._polling_task = None
+
+    async def start_polling_for_definitions(self):
+        await self._fetch_flag_definitions()
+
+        if self._config.enablePolling:
+            if not self._polling_task:
+                self._polling_task = asyncio.create_task(self._start_continuous_polling())
+            else:
+                logging.Error("Polling task is already running")
+
+    async def _start_continuous_polling(self):
+        logging.info(f"Initialized async polling for flag definition updates every {self._config.pollingIntervalInSeconds} seconds")
+        while True:
+            await asyncio.sleep(self._config.pollingIntervalInSeconds)
+            await self._fetch_flag_definitions()
+
+    def are_flags_ready(self) -> bool:
+        """
+        Check if flag definitions have been loaded and are ready for use.
+        :return: True if flag definitions are populated, False otherwise.
+        """
+        return bool(self._flag_definitions)
+
+    def get_variant_value(self, flag_key: str, fallback_value: str, context: Dict[str, str]) -> str:
+        variant = self.get_variant(flag_key, SelectedVariant(variant_key=fallback_value, variant_value=fallback_value), context)
+        return variant.variant_value
+
+    def is_enabled(self, flag_key: str, context: Dict[str, str]) -> bool:
+        variant = self.get_variant_value(flag_key, False, context)
+        return bool(variant)
+
+    def get_variant(self, flag_key: str, fallback_value: SelectedVariant, context: Dict[str, str]) -> SelectedVariant:
+        start_time = time.perf_counter()
+        flag_definition = self._flag_definitions.get(flag_key)
+
+        if not flag_definition:
+            logger.warning(f"Cannot find flag definition for key: {flag_key}")
+            return fallback_value
+
+        if not(context_value := context.get(flag_definition.context)):
+            logger.warning(f"The rollout context, {flag_definition.context} for flag, {flag_key} is not present in the supplied context dictionary")
+            return fallback_value
+
+        if test_user_variant := self._get_variant_override_for_test_user(flag_definition, context):
+            return test_user_variant
+
+        if rollout := self._get_assigned_rollout(flag_definition, context_value, context):
+            variant = self._get_assigned_variant(flag_definition, context_value, flag_key, rollout)
+            end_time = time.perf_counter()
+            self.track_exposure(flag_key, variant, end_time - start_time, context)
+            return variant
+
+        logger.info(f"{flag_definition.context} context {context_value} not eligible for any rollout for flag: {flag_key}")
+        return fallback_value
+
+    def _get_variant_override_for_test_user(self, flag_definition: ExperimentationFlag, context: Dict[str, str]) -> Optional[SelectedVariant]:
+        """"""
+        if not flag_definition.ruleset.test or not flag_definition.ruleset.test.users:
+            return None
+
+        if not (distinct_id := context.get("distinct_id")):
+            return None
+
+        if not (variant_key := flag_definition.ruleset.test.users.get(distinct_id)):
+            return None
+
+        return self._get_matching_variant(variant_key, flag_definition)
+
+    def _get_assigned_variant(self, flag_definition: ExperimentationFlag, context_value: Any, flagName: str, rollout: Rollout) -> SelectedVariant:
+        if rollout.variant_override:
+            if variant := self._get_matching_variant(rollout.variant_override.key, flag_definition):
+                return variant
+
+        variants = flag_definition.ruleset.variants
+        hash_input = str(context_value) + flagName
+
+        variant_hash = normalized_hash(hash_input, "variant")
+
+        selected = None
+        last = None
+        cumulative = 0.0
+        for variant in variants:
+            last = variant
+            cumulative += variant.split
+            if variant_hash < cumulative:
+                selected = variant
+                break
+
+        chosen_variant = selected if selected else last
+
+        return SelectedVariant(variant_key=chosen_variant.key, variant_value=chosen_variant.value)
+
+    def _get_assigned_rollout(self, flag_definition: ExperimentationFlag, context_value: Any, context: Dict[str, str]) -> Optional[Rollout]:
+        hash_input = str(context_value) + flag_definition.key
+
+        rollout_hash = normalized_hash(hash_input, "rollout")
+
+        for rollout in flag_definition.ruleset.rollout:
+            if rollout_hash < rollout.rollout_percentage and self._is_runtime_evaluation_satisfied(rollout, context):
+                return rollout
+
+        return None
+
+    def _is_runtime_evaluation_satisfied(self, rollout: Rollout, context: Dict[str, str]) -> bool:
+        if not rollout.runtime_evaluation_definition:
+            return True
+
+        if not (custom_properties := context.get("custom_properties")):
+            return False
+
+        if not isinstance(custom_properties, dict):
+            return False
+
+        for key, expected_value in rollout.runtime_evaluation_definition.items():
+            if key not in custom_properties:
+                return False
+
+            actual_value = custom_properties[key]
+            if actual_value.casefold() != expected_value.casefold():
+                return False
+
+        return True
+
+    def _get_matching_variant(self, variant_key: str, flag :ExperimentationFlag) -> Optional[SelectedVariant]:
+        for variant in flag.ruleset.variants:
+            if variant_key.casefold() == variant.key.casefold():
+                return SelectedVariant(variant_key=variant.key, variant_value=variant.value)
+        return None
+
+    async def _fetch_flag_definitions(self) -> None:
+        try:
+            start_time = datetime.now()
+            response = await self.async_client.get(self.FLAGS_DEFINITIONS_URL_PATH)
+            end_time = datetime.now()
+            request_duration: timedelta = end_time - start_time
+            logging.info(f"Request started at {start_time.isoformat()}, completed at {end_time.isoformat()}, duration: {request_duration.total_seconds():.3f}s")
+
+            response.raise_for_status()
+
+            flags = {}
+            try:
+                json_data = response.json()
+                experimentation_flags = ExperimentationFlags.model_validate(json_data)
+                for flag in experimentation_flags.flags:
+                    flags[flag.key] = flag
+            except Exception as e:
+                logger.error("Failed to parse flag definitions: {}".format(e))
+
+            self._flag_definitions = flags
+            logger.info("Successfully fetched {} flag definitions".format(len(self._flag_definitions)))
+        except Exception as e:
+            logger.error("Failed to fetch feature flag definitions: {}".format(e))
+
+    def track_exposure(self, flag_key: str, variant: SelectedVariant, latencyInSeconds: float, context: Dict[str, str]):
+        additional_properties = {
+            "Flag evaluation mode": "remote",
+            "Variant fetch latency (ms)": latencyInSeconds * 1000
+        }
+
+        if distinct_id := context.get("distinct_id"):
+            track_exposure_event(
+                distinct_id=distinct_id,
+                flag_key=flag_key,
+                variant=variant,
+                additional_properties=additional_properties,
+                tracker=self._tracker)
+        else:
+            logging.error("Cannot track exposure event without a distinct_id in the context")
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        logging.info("Exiting the LocalFeatureFlagsProvider and cleaning up resources")
+        if self._polling_task and not self._polling_task.done():
+            result =  self._polling_task.cancel()
+            logging.info(f"Polling task cancellation completed with result: {result}")
+
+        await self.async_client.aclose()

--- a/mixpanel/flags/local_feature_flags.py
+++ b/mixpanel/flags/local_feature_flags.py
@@ -2,9 +2,10 @@ import httpx
 import logging
 import asyncio
 import time
+import threading
 from datetime import datetime, timedelta
 from typing import Dict, Any, Callable, Optional
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import Future, ThreadPoolExecutor
 from .types import ExperimentationFlag, ExperimentationFlags, SelectedVariant, LocalFlagsConfig, Rollout
 from .utils import REQUEST_HEADERS, normalized_hash, prepare_common_query_params, EXPOSURE_EVENT
 
@@ -35,37 +36,60 @@ class LocalFeatureFlagsProvider:
         self._async_client: httpx.AsyncClient = httpx.AsyncClient(**httpx_client_parameters)
         self._sync_client: httpx.Client = httpx.Client(**httpx_client_parameters)
 
-        self._async_polling_task = None
-        self._sync_polling_task = None
+        self._async_polling_task: Optional[asyncio.Task] = None
+        self._sync_polling_task: Optional[Future] = None
+
+        self._sync_stop_event = threading.Event()
 
     def start_polling_for_definitions(self):
         self._fetch_flag_definitions()
 
         if self._config.enable_polling:
             if not self._sync_polling_task and not self._async_polling_task:
+                self._sync_stop_event.clear()
                 self._sync_polling_task = self._executor.submit(self._start_continuous_polling)
             else:
                 logging.error("A polling task is already running")
+
+    def stop_polling_for_definitions(self):
+        if self._sync_polling_task:
+            self._sync_stop_event.set()
+            self._sync_polling_task.cancel()
+            self._sync_polling_task = None
+        else:
+            logging.info("There is no polling task to cancel.")
 
     async def astart_polling_for_definitions(self):
         await self._afetch_flag_definitions()
 
         if self._config.enable_polling:
             if not self._sync_polling_task and not self._async_polling_task:
-                self._polling_task = asyncio.create_task(self._astart_continuous_polling())
+                self._async_polling_task = asyncio.create_task(self._astart_continuous_polling())
             else:
                 logging.error("A polling task is already running")
 
+    async def astop_polling_for_definitions(self):
+        if self._async_polling_task:
+            self._async_polling_task.cancel()
+            self._async_polling_task = None
+        else:
+            logging.info("There is no polling task to cancel.")
+
     async def _astart_continuous_polling(self):
-        logging.info(f"Initialized async polling for flag definition updates every {self._config.polling_interval_in_seconds} seconds")
-        while True:
-            await asyncio.sleep(self._config.polling_interval_in_seconds)
-            await self._afetch_flag_definitions()
+        logging.info(f"Initialized async polling for flag definition updates every '{self._config.polling_interval_in_seconds}' seconds")
+        try:
+            while True:
+                await asyncio.sleep(self._config.polling_interval_in_seconds)
+                await self._afetch_flag_definitions()
+        except asyncio.CancelledError:
+            logging.info("Async polling was cancelled")
 
     def _start_continuous_polling(self):
-        logging.info(f"Initialized sync polling for flag definition updates every {self._config.polling_interval_in_seconds} seconds")
-        while True:
-            time.sleep(self._config.polling_interval_in_seconds)
+        logging.info(f"Initialized sync polling for flag definition updates every '{self._config.polling_interval_in_seconds}' seconds")
+        while not self._sync_stop_event.is_set():
+            if self._sync_stop_event.wait(timeout=self._config.polling_interval_in_seconds):
+                break
+
             self._fetch_flag_definitions()
 
     def are_flags_ready(self) -> bool:
@@ -76,23 +100,23 @@ class LocalFeatureFlagsProvider:
         return bool(self._flag_definitions)
 
     def get_variant_value(self, flag_key: str, fallback_value: Any, context: Dict[str, Any]) -> Any:
-        variant = self.get_variant(flag_key, SelectedVariant(variant_key=fallback_value, variant_value=fallback_value), context)
+        variant = self.get_variant(flag_key, SelectedVariant(variant_value=fallback_value), context)
         return variant.variant_value
 
     def is_enabled(self, flag_key: str, context: Dict[str, Any]) -> bool:
-        variant = self.get_variant_value(flag_key, "false" , context)
-        return bool(variant)
+        variant_value = self.get_variant_value(flag_key, False, context)
+        return bool(variant_value)
 
     def get_variant(self, flag_key: str, fallback_value: SelectedVariant, context: Dict[str, Any]) -> SelectedVariant:
         start_time = time.perf_counter()
         flag_definition = self._flag_definitions.get(flag_key)
 
         if not flag_definition:
-            logger.warning(f"Cannot find flag definition for key: {flag_key}")
+            logger.warning(f"Cannot find flag definition for key: '{flag_key}'")
             return fallback_value
 
         if not(context_value := context.get(flag_definition.context)):
-            logger.warning(f"The rollout context, {flag_definition.context} for flag, {flag_key} is not present in the supplied context dictionary")
+            logger.warning(f"The rollout context, '{flag_definition.context}' for flag, '{flag_key}' is not present in the supplied context dictionary")
             return fallback_value
 
         if test_user_variant := self._get_variant_override_for_test_user(flag_definition, context):
@@ -184,8 +208,8 @@ class LocalFeatureFlagsProvider:
             response = await self._async_client.get(self.FLAGS_DEFINITIONS_URL_PATH, params=self._request_params)
             end_time = datetime.now()
             self._handle_response(response, start_time, end_time)
-        except Exception as e:
-            logger.error("Failed to fetch feature flag definitions: {}".format(e))
+        except Exception:
+            logger.exception("Failed to fetch feature flag definitions")
 
     def _fetch_flag_definitions(self) -> None:
         try:
@@ -193,12 +217,12 @@ class LocalFeatureFlagsProvider:
             response = self._sync_client.get(self.FLAGS_DEFINITIONS_URL_PATH, params=self._request_params)
             end_time = datetime.now()
             self._handle_response(response, start_time, end_time)
-        except Exception as e:
-            logger.error("Failed to fetch feature flag definitions: {}".format(e))
+        except Exception:
+            logger.exception("Failed to fetch feature flag definitions")
 
     def _handle_response(self, response: httpx.Response, start_time: datetime, end_time: datetime) -> None:
         request_duration: timedelta = end_time - start_time
-        logging.info(f"Request started at {start_time.isoformat()}, completed at {end_time.isoformat()}, duration: {request_duration.total_seconds():.3f}s")
+        logging.info(f"Request started at '{start_time.isoformat()}', completed at '{end_time.isoformat()}', duration: '{request_duration.total_seconds():.3f}s'")
 
         response.raise_for_status()
 
@@ -209,11 +233,11 @@ class LocalFeatureFlagsProvider:
             for flag in experimentation_flags.flags:
                 flag.ruleset.variants.sort(key=lambda variant: variant.key)
                 flags[flag.key] = flag
-        except Exception as e:
-            logger.error("Failed to parse flag definitions: {}".format(e))
+        except Exception:
+            logger.exception("Failed to parse flag definitions")
 
         self._flag_definitions = flags
-        logger.info("Successfully fetched {} flag definitions".format(len(self._flag_definitions)))
+        logger.info(f"Successfully fetched {len(self._flag_definitions)} flag definitions")
 
 
     def track_exposure(self, flag_key: str, variant: SelectedVariant, latency_in_seconds: float, context: Dict[str, Any]):
@@ -237,17 +261,10 @@ class LocalFeatureFlagsProvider:
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         logging.info("Exiting the LocalFeatureFlagsProvider and cleaning up resources")
-        if self._async_polling_task:
-            result =  self._async_polling_task.cancel()
-            logging.info(f"Polling task cancellation completed with result: {result}")
-
+        await self.astop_polling_for_definitions()
         await self._async_client.aclose()
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         logging.info("Exiting the LocalFeatureFlagsProvider and cleaning up resources")
-        if self._sync_polling_task:
-            result = self._sync_polling_task.cancel()
-            logging.info(f"Polling task cancellation completed with result: {result}")
-
+        self.stop_polling_for_definitions()
         self._sync_client.close()
-        pass

--- a/mixpanel/flags/local_feature_flags.py
+++ b/mixpanel/flags/local_feature_flags.py
@@ -30,20 +30,20 @@ class LocalFeatureFlagsProvider:
         self.async_client: httpx.AsyncClient = httpx.AsyncClient(**httpx_client_parameters)
         self._polling_task = None
 
-    async def start_polling_for_definitions(self):
-        await self._fetch_flag_definitions()
+    async def astart_polling_for_definitions(self):
+        await self._afetch_flag_definitions()
 
         if self._config.enablePolling:
             if not self._polling_task:
-                self._polling_task = asyncio.create_task(self._start_continuous_polling())
+                self._polling_task = asyncio.create_task(self._astart_continuous_polling())
             else:
                 logging.Error("Polling task is already running")
 
-    async def _start_continuous_polling(self):
+    async def _astart_continuous_polling(self):
         logging.info(f"Initialized async polling for flag definition updates every {self._config.pollingIntervalInSeconds} seconds")
         while True:
             await asyncio.sleep(self._config.pollingIntervalInSeconds)
-            await self._fetch_flag_definitions()
+            await self._afetch_flag_definitions()
 
     def are_flags_ready(self) -> bool:
         """
@@ -158,7 +158,7 @@ class LocalFeatureFlagsProvider:
                 return SelectedVariant(variant_key=variant.key, variant_value=variant.value)
         return None
 
-    async def _fetch_flag_definitions(self) -> None:
+    async def _afetch_flag_definitions(self) -> None:
         try:
             start_time = datetime.now()
             response = await self.async_client.get(self.FLAGS_DEFINITIONS_URL_PATH)

--- a/mixpanel/flags/local_feature_flags.py
+++ b/mixpanel/flags/local_feature_flags.py
@@ -173,6 +173,7 @@ class LocalFeatureFlagsProvider:
                 json_data = response.json()
                 experimentation_flags = ExperimentationFlags.model_validate(json_data)
                 for flag in experimentation_flags.flags:
+                    flag.ruleset.variants.sort(key=lambda variant: variant.key)
                     flags[flag.key] = flag
             except Exception as e:
                 logger.error("Failed to parse flag definitions: {}".format(e))

--- a/mixpanel/flags/local_feature_flags.py
+++ b/mixpanel/flags/local_feature_flags.py
@@ -5,7 +5,8 @@ import time
 from datetime import datetime, timedelta
 from typing import Dict, Any, Callable, Optional
 from .types import ExperimentationFlag, ExperimentationFlags, SelectedVariant, LocalFlagsConfig, Rollout
-from .utils import REQUEST_HEADERS, normalized_hash, track_exposure_event
+from .utils import REQUEST_HEADERS, normalized_hash, track_exposure_event, prepare_common_query_params
+from .. import __version__
 
 logger = logging.getLogger(__name__)
 logging.getLogger("httpx").setLevel(logging.ERROR)
@@ -161,7 +162,8 @@ class LocalFeatureFlagsProvider:
     async def _afetch_flag_definitions(self) -> None:
         try:
             start_time = datetime.now()
-            response = await self.async_client.get(self.FLAGS_DEFINITIONS_URL_PATH)
+            params = prepare_common_query_params(self._token, __version__)
+            response = await self.async_client.get(self.FLAGS_DEFINITIONS_URL_PATH, params=params)
             end_time = datetime.now()
             request_duration: timedelta = end_time - start_time
             logging.info(f"Request started at {start_time.isoformat()}, completed at {end_time.isoformat()}, duration: {request_duration.total_seconds():.3f}s")

--- a/mixpanel/flags/local_feature_flags.py
+++ b/mixpanel/flags/local_feature_flags.py
@@ -4,9 +4,9 @@ import asyncio
 import time
 from datetime import datetime, timedelta
 from typing import Dict, Any, Callable, Optional
+from concurrent.futures import ThreadPoolExecutor
 from .types import ExperimentationFlag, ExperimentationFlags, SelectedVariant, LocalFlagsConfig, Rollout
-from .utils import REQUEST_HEADERS, normalized_hash, track_exposure_event, prepare_common_query_params
-from .. import __version__
+from .utils import REQUEST_HEADERS, normalized_hash, prepare_common_query_params, EXPOSURE_EVENT
 
 logger = logging.getLogger(__name__)
 logging.getLogger("httpx").setLevel(logging.ERROR)
@@ -14,10 +14,12 @@ logging.getLogger("httpx").setLevel(logging.ERROR)
 class LocalFeatureFlagsProvider:
     FLAGS_DEFINITIONS_URL_PATH = "/flags/definitions"
 
-    def __init__(self, token: str, config: LocalFlagsConfig, tracker: Callable) -> None:
+    def __init__(self, token: str, config: LocalFlagsConfig, version: str, tracker: Callable) -> None:
         self._token: str = token
         self._config: LocalFlagsConfig = config
+        self._version = version
         self._tracker: Callable = tracker
+        self._executor: ThreadPoolExecutor = config.custom_executor or ThreadPoolExecutor(max_workers=5)
 
         self._flag_definitions: Dict[str, ExperimentationFlag] = dict()
 
@@ -25,26 +27,46 @@ class LocalFeatureFlagsProvider:
             "base_url": f"https://{config.api_host}",
             "headers": REQUEST_HEADERS,
             "auth": httpx.BasicAuth(token, ""),
-            "timeout": httpx.Timeout(config.requestTimeoutInSeconds),
+            "timeout": httpx.Timeout(config.request_timeout_in_seconds),
         }
 
-        self.async_client: httpx.AsyncClient = httpx.AsyncClient(**httpx_client_parameters)
-        self._polling_task = None
+        self._request_params = prepare_common_query_params(self._token, self._version)
+
+        self._async_client: httpx.AsyncClient = httpx.AsyncClient(**httpx_client_parameters)
+        self._sync_client: httpx.Client = httpx.Client(**httpx_client_parameters)
+
+        self._async_polling_task = None
+        self._sync_polling_task = None
+
+    def start_polling_for_definitions(self):
+        self._fetch_flag_definitions()
+
+        if self._config.enable_polling:
+            if not self._sync_polling_task and not self._async_polling_task:
+                self._sync_polling_task = self._executor.submit(self._start_continuous_polling)
+            else:
+                logging.error("A polling task is already running")
 
     async def astart_polling_for_definitions(self):
         await self._afetch_flag_definitions()
 
-        if self._config.enablePolling:
-            if not self._polling_task:
+        if self._config.enable_polling:
+            if not self._sync_polling_task and not self._async_polling_task:
                 self._polling_task = asyncio.create_task(self._astart_continuous_polling())
             else:
-                logging.Error("Polling task is already running")
+                logging.error("A polling task is already running")
 
     async def _astart_continuous_polling(self):
-        logging.info(f"Initialized async polling for flag definition updates every {self._config.pollingIntervalInSeconds} seconds")
+        logging.info(f"Initialized async polling for flag definition updates every {self._config.polling_interval_in_seconds} seconds")
         while True:
-            await asyncio.sleep(self._config.pollingIntervalInSeconds)
+            await asyncio.sleep(self._config.polling_interval_in_seconds)
             await self._afetch_flag_definitions()
+
+    def _start_continuous_polling(self):
+        logging.info(f"Initialized sync polling for flag definition updates every {self._config.polling_interval_in_seconds} seconds")
+        while True:
+            time.sleep(self._config.polling_interval_in_seconds)
+            self._fetch_flag_definitions()
 
     def are_flags_ready(self) -> bool:
         """
@@ -53,15 +75,15 @@ class LocalFeatureFlagsProvider:
         """
         return bool(self._flag_definitions)
 
-    def get_variant_value(self, flag_key: str, fallback_value: str, context: Dict[str, str]) -> str:
+    def get_variant_value(self, flag_key: str, fallback_value: Any, context: Dict[str, Any]) -> Any:
         variant = self.get_variant(flag_key, SelectedVariant(variant_key=fallback_value, variant_value=fallback_value), context)
         return variant.variant_value
 
-    def is_enabled(self, flag_key: str, context: Dict[str, str]) -> bool:
-        variant = self.get_variant_value(flag_key, False, context)
+    def is_enabled(self, flag_key: str, context: Dict[str, Any]) -> bool:
+        variant = self.get_variant_value(flag_key, "false" , context)
         return bool(variant)
 
-    def get_variant(self, flag_key: str, fallback_value: SelectedVariant, context: Dict[str, str]) -> SelectedVariant:
+    def get_variant(self, flag_key: str, fallback_value: SelectedVariant, context: Dict[str, Any]) -> SelectedVariant:
         start_time = time.perf_counter()
         flag_definition = self._flag_definitions.get(flag_key)
 
@@ -85,7 +107,7 @@ class LocalFeatureFlagsProvider:
         logger.info(f"{flag_definition.context} context {context_value} not eligible for any rollout for flag: {flag_key}")
         return fallback_value
 
-    def _get_variant_override_for_test_user(self, flag_definition: ExperimentationFlag, context: Dict[str, str]) -> Optional[SelectedVariant]:
+    def _get_variant_override_for_test_user(self, flag_definition: ExperimentationFlag, context: Dict[str, Any]) -> Optional[SelectedVariant]:
         """"""
         if not flag_definition.ruleset.test or not flag_definition.ruleset.test.users:
             return None
@@ -98,31 +120,28 @@ class LocalFeatureFlagsProvider:
 
         return self._get_matching_variant(variant_key, flag_definition)
 
-    def _get_assigned_variant(self, flag_definition: ExperimentationFlag, context_value: Any, flagName: str, rollout: Rollout) -> SelectedVariant:
+    def _get_assigned_variant(self, flag_definition: ExperimentationFlag, context_value: Any, flag_name: str, rollout: Rollout) -> SelectedVariant:
         if rollout.variant_override:
             if variant := self._get_matching_variant(rollout.variant_override.key, flag_definition):
                 return variant
 
         variants = flag_definition.ruleset.variants
-        hash_input = str(context_value) + flagName
+
+        hash_input = str(context_value) + flag_name
 
         variant_hash = normalized_hash(hash_input, "variant")
 
-        selected = None
-        last = None
+        selected = variants[0]
         cumulative = 0.0
         for variant in variants:
-            last = variant
+            selected = variant
             cumulative += variant.split
             if variant_hash < cumulative:
-                selected = variant
                 break
 
-        chosen_variant = selected if selected else last
+        return SelectedVariant(variant_key=selected.key, variant_value=selected.value)
 
-        return SelectedVariant(variant_key=chosen_variant.key, variant_value=chosen_variant.value)
-
-    def _get_assigned_rollout(self, flag_definition: ExperimentationFlag, context_value: Any, context: Dict[str, str]) -> Optional[Rollout]:
+    def _get_assigned_rollout(self, flag_definition: ExperimentationFlag, context_value: Any, context: Dict[str, Any]) -> Optional[Rollout]:
         hash_input = str(context_value) + flag_definition.key
 
         rollout_hash = normalized_hash(hash_input, "rollout")
@@ -133,7 +152,7 @@ class LocalFeatureFlagsProvider:
 
         return None
 
-    def _is_runtime_evaluation_satisfied(self, rollout: Rollout, context: Dict[str, str]) -> bool:
+    def _is_runtime_evaluation_satisfied(self, rollout: Rollout, context: Dict[str, Any]) -> bool:
         if not rollout.runtime_evaluation_definition:
             return True
 
@@ -153,7 +172,7 @@ class LocalFeatureFlagsProvider:
 
         return True
 
-    def _get_matching_variant(self, variant_key: str, flag :ExperimentationFlag) -> Optional[SelectedVariant]:
+    def _get_matching_variant(self, variant_key: str, flag: ExperimentationFlag) -> Optional[SelectedVariant]:
         for variant in flag.ruleset.variants:
             if variant_key.casefold() == variant.key.casefold():
                 return SelectedVariant(variant_key=variant.key, variant_value=variant.value)
@@ -162,52 +181,73 @@ class LocalFeatureFlagsProvider:
     async def _afetch_flag_definitions(self) -> None:
         try:
             start_time = datetime.now()
-            params = prepare_common_query_params(self._token, __version__)
-            response = await self.async_client.get(self.FLAGS_DEFINITIONS_URL_PATH, params=params)
+            response = await self._async_client.get(self.FLAGS_DEFINITIONS_URL_PATH, params=self._request_params)
             end_time = datetime.now()
-            request_duration: timedelta = end_time - start_time
-            logging.info(f"Request started at {start_time.isoformat()}, completed at {end_time.isoformat()}, duration: {request_duration.total_seconds():.3f}s")
-
-            response.raise_for_status()
-
-            flags = {}
-            try:
-                json_data = response.json()
-                experimentation_flags = ExperimentationFlags.model_validate(json_data)
-                for flag in experimentation_flags.flags:
-                    flag.ruleset.variants.sort(key=lambda variant: variant.key)
-                    flags[flag.key] = flag
-            except Exception as e:
-                logger.error("Failed to parse flag definitions: {}".format(e))
-
-            self._flag_definitions = flags
-            logger.info("Successfully fetched {} flag definitions".format(len(self._flag_definitions)))
+            self._handle_response(response, start_time, end_time)
         except Exception as e:
             logger.error("Failed to fetch feature flag definitions: {}".format(e))
 
-    def track_exposure(self, flag_key: str, variant: SelectedVariant, latencyInSeconds: float, context: Dict[str, str]):
-        additional_properties = {
-            "Flag evaluation mode": "remote",
-            "Variant fetch latency (ms)": latencyInSeconds * 1000
-        }
+    def _fetch_flag_definitions(self) -> None:
+        try:
+            start_time = datetime.now()
+            response = self._sync_client.get(self.FLAGS_DEFINITIONS_URL_PATH, params=self._request_params)
+            end_time = datetime.now()
+            self._handle_response(response, start_time, end_time)
+        except Exception as e:
+            logger.error("Failed to fetch feature flag definitions: {}".format(e))
 
+    def _handle_response(self, response: httpx.Response, start_time: datetime, end_time: datetime) -> None:
+        request_duration: timedelta = end_time - start_time
+        logging.info(f"Request started at {start_time.isoformat()}, completed at {end_time.isoformat()}, duration: {request_duration.total_seconds():.3f}s")
+
+        response.raise_for_status()
+
+        flags = {}
+        try:
+            json_data = response.json()
+            experimentation_flags = ExperimentationFlags.model_validate(json_data)
+            for flag in experimentation_flags.flags:
+                flag.ruleset.variants.sort(key=lambda variant: variant.key)
+                flags[flag.key] = flag
+        except Exception as e:
+            logger.error("Failed to parse flag definitions: {}".format(e))
+
+        self._flag_definitions = flags
+        logger.info("Successfully fetched {} flag definitions".format(len(self._flag_definitions)))
+
+
+    def track_exposure(self, flag_key: str, variant: SelectedVariant, latency_in_seconds: float, context: Dict[str, Any]):
         if distinct_id := context.get("distinct_id"):
-            track_exposure_event(
-                distinct_id=distinct_id,
-                flag_key=flag_key,
-                variant=variant,
-                additional_properties=additional_properties,
-                tracker=self._tracker)
+            properties = {
+                'Experiment name': flag_key,
+                'Variant name': variant.variant_key,
+                '$experiment_type': 'feature_flag',
+                "Flag evaluation mode": "local",
+                "Variant fetch latency (ms)": latency_in_seconds * 1000
+            }
+            self._executor.submit(self._tracker, distinct_id, EXPOSURE_EVENT, properties)
         else:
             logging.error("Cannot track exposure event without a distinct_id in the context")
 
     async def __aenter__(self):
         return self
 
+    def __enter__(self):
+        return self
+
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         logging.info("Exiting the LocalFeatureFlagsProvider and cleaning up resources")
-        if self._polling_task and not self._polling_task.done():
-            result =  self._polling_task.cancel()
+        if self._async_polling_task:
+            result =  self._async_polling_task.cancel()
             logging.info(f"Polling task cancellation completed with result: {result}")
 
-        await self.async_client.aclose()
+        await self._async_client.aclose()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        logging.info("Exiting the LocalFeatureFlagsProvider and cleaning up resources")
+        if self._sync_polling_task:
+            result = self._sync_polling_task.cancel()
+            logging.info(f"Polling task cancellation completed with result: {result}")
+
+        self._sync_client.close()
+        pass

--- a/mixpanel/flags/remote_feature_flags.py
+++ b/mixpanel/flags/remote_feature_flags.py
@@ -6,7 +6,8 @@ from datetime import datetime, timedelta
 from typing import Dict, Any, Callable
 
 from .types import RemoteFlagsConfig, SelectedVariant, RemoteFlagsResponse
-from .utils import REQUEST_HEADERS, track_exposure_event
+from .utils import REQUEST_HEADERS, track_exposure_event, prepare_common_query_params
+from .. import __version__
 
 logger = logging.getLogger(__name__)
 logging.getLogger("httpx").setLevel(logging.ERROR)
@@ -67,12 +68,13 @@ class RemoteFeatureFlagsProvider:
         return bool(variant.variant_value)
 
     def _prepare_query_params(self, flag_key: str, context: Dict[str, str]) -> Dict[str, str]:
+        params = prepare_common_query_params(self._token, __version__)
         context_json = json.dumps(context).encode('utf-8')
         url_encoded_context = urllib.parse.quote(context_json)
-        params = {
+        params.update({
             'flag_key': flag_key,
-            "context": url_encoded_context
-        }
+            'context': url_encoded_context
+        })
         return params
 
     def _handle_response(self, context: Dict[str, str], flag_key: str, fallback_value: SelectedVariant, response: httpx.Response, start_time: datetime, end_time: datetime) -> SelectedVariant:

--- a/mixpanel/flags/remote_feature_flags.py
+++ b/mixpanel/flags/remote_feature_flags.py
@@ -2,12 +2,14 @@ import httpx
 import logging
 import json
 import urllib.parse
-from datetime import datetime, timedelta
+import asyncio
+from datetime import datetime 
 from typing import Dict, Any, Callable
+from asgiref.sync import sync_to_async
 
 from .types import RemoteFlagsConfig, SelectedVariant, RemoteFlagsResponse
-from .utils import REQUEST_HEADERS, track_exposure_event, prepare_common_query_params
-from .. import __version__
+from concurrent.futures import ThreadPoolExecutor
+from .utils import REQUEST_HEADERS, EXPOSURE_EVENT, prepare_common_query_params
 
 logger = logging.getLogger(__name__)
 logging.getLogger("httpx").setLevel(logging.ERROR)
@@ -15,60 +17,79 @@ logging.getLogger("httpx").setLevel(logging.ERROR)
 class RemoteFeatureFlagsProvider:
     FLAGS_URL_PATH = "/flags"
 
-    def __init__(self, token: str, config: RemoteFlagsConfig, tracker: Callable) -> None:
+    def __init__(self, token: str, config: RemoteFlagsConfig, version: str, tracker: Callable) -> None:
+        self._token: str = token
         self._config: RemoteFlagsConfig = config
+        self._version: str = version
         self._tracker: Callable = tracker
+        self._executor: ThreadPoolExecutor = config.custom_executor or ThreadPoolExecutor(max_workers=5)
 
         httpx_client_parameters = {
             "base_url": f"https://{config.api_host}",
             "headers": REQUEST_HEADERS,
             "auth": httpx.BasicAuth(token, ""),
-            "timeout": httpx.Timeout(config.requestTimeoutInSeconds),
+            "timeout": httpx.Timeout(config.request_timeout_in_seconds),
         }
 
-        self.async_client: httpx.AsyncClient = httpx.AsyncClient(**httpx_client_parameters)
-        self.sync_client: httpx.Client = httpx.Client(**httpx_client_parameters)
+        self._async_client: httpx.AsyncClient = httpx.AsyncClient(**httpx_client_parameters)
+        self._sync_client: httpx.Client = httpx.Client(**httpx_client_parameters)
+        self._request_params_base = prepare_common_query_params(self._token, version)
 
-    async def aget_variant_value(self, flag_key: str, fallback_value: str, context: Dict[str, str]) -> SelectedVariant:
+    async def aget_variant_value(self, flag_key: str, fallback_value: Any, context: Dict[str, Any]) -> Any:
         variant = await self.aget_variant(flag_key, SelectedVariant(variant_key=fallback_value, variant_value=fallback_value), context)
         return variant.variant_value
 
-    async def aget_variant(self, flag_key: str, fallback_value: SelectedVariant, context: Dict[str, str]) -> SelectedVariant:
+    async def aget_variant(self, flag_key: str, fallback_value: SelectedVariant, context: Dict[str, Any]) -> SelectedVariant:
         try:
             params = self._prepare_query_params(flag_key, context)
             start_time = datetime.now()
-            response = await self.async_client.get(self.FLAGS_URL_PATH, params=params)
+            response = await self._async_client.get(self.FLAGS_URL_PATH, params=params)
             end_time = datetime.now()
-            return self._handle_response(context, flag_key, fallback_value, response, start_time, end_time)
+            self._instrument_call(start_time, end_time)
+            selected_variant, is_fallback = self._handle_response(flag_key, fallback_value, response)
+
+            if not is_fallback and (distinct_id := context.get("distinct_id")):
+                properties = self._build_tracking_properties(flag_key, selected_variant, start_time, end_time)
+                asyncio.create_task(
+                    sync_to_async(self._tracker, executor=self._executor, thread_sensitive=False)(distinct_id, EXPOSURE_EVENT, properties))
+
+            return selected_variant
         except Exception:
             logging.exception(f"Failed to get remote variant for flag {flag_key}")
             return fallback_value
 
-    async def ais_enabled(self, flag_key: str, context: Dict[str, str]) -> bool:
+    async def ais_enabled(self, flag_key: str, context: Dict[str, Any]) -> bool:
         variant = await self.aget_variant_value(flag_key, "false", context)
         return bool(variant.variant_value)
 
-    def get_variant_value(self, flag_key: str, fallback_value: Any, context: Dict[str, str]) -> SelectedVariant:
+    def get_variant_value(self, flag_key: str, fallback_value: Any, context: Dict[str, Any]) -> Any:
         variant = self.get_variant(flag_key, SelectedVariant(variant_key=fallback_value, variant_value=fallback_value), context)
         return variant.variant_value
 
-    def get_variant(self, flag_key: str, fallback_value: SelectedVariant, context: Dict[str, str]) -> SelectedVariant:
+    def get_variant(self, flag_key: str, fallback_value: SelectedVariant, context: Dict[str, Any]) -> SelectedVariant:
         try:
             params = self._prepare_query_params(flag_key, context)
             start_time = datetime.now()
-            response = self.sync_client.get(self.FLAGS_URL_PATH, params=params)
+            response = self._sync_client.get(self.FLAGS_URL_PATH, params=params)
             end_time = datetime.now()
-            return self._handle_response(context, flag_key, fallback_value, response, start_time, end_time)
+            self._instrument_call(start_time, end_time)
+            selected_variant, is_fallback = self._handle_response(flag_key, fallback_value, response)
+
+            if not is_fallback and (distinct_id := context.get("distinct_id")):
+                properties = self._build_tracking_properties(flag_key, selected_variant, start_time, end_time)
+                self._executor.submit(self._tracker, distinct_id, EXPOSURE_EVENT, properties)
+
+            return selected_variant
         except Exception:
             logging.exception(f"Failed to get remote variant for flag {flag_key}")
             return fallback_value
 
-    def is_enabled(self, flag_key: str, context: Dict[str, str]) -> bool:
+    def is_enabled(self, flag_key: str, context: Dict[str, Any]) -> bool:
         variant = self.get_variant_value(flag_key, "false", context)
         return bool(variant.variant_value)
 
-    def _prepare_query_params(self, flag_key: str, context: Dict[str, str]) -> Dict[str, str]:
-        params = prepare_common_query_params(self._token, __version__)
+    def _prepare_query_params(self, flag_key: str, context: Dict[str, Any]) -> Dict[str, str]:
+        params = self._request_params_base.copy()
         context_json = json.dumps(context).encode('utf-8')
         url_encoded_context = urllib.parse.quote(context_json)
         params.update({
@@ -77,37 +98,37 @@ class RemoteFeatureFlagsProvider:
         })
         return params
 
-    def _handle_response(self, context: Dict[str, str], flag_key: str, fallback_value: SelectedVariant, response: httpx.Response, start_time: datetime, end_time: datetime) -> SelectedVariant:
-        request_duration: timedelta = (end_time - start_time)
-        formatted_start_time, formatted_end_time = start_time.isoformat(), end_time.isoformat()
+    def _instrument_call(self, start_time: datetime, end_time: datetime) -> None:
+        request_duration = end_time - start_time
+        formatted_start_time = start_time.isoformat()
+        formatted_end_time = end_time.isoformat()
         logging.info(f"Request started at {formatted_start_time}, completed at {formatted_end_time}, duration: {request_duration.total_seconds():.3f}s")
 
+    def _build_tracking_properties(self, flag_key: str, variant: SelectedVariant, start_time: datetime, end_time: datetime) -> Dict[str, Any]:
+        request_duration = end_time - start_time
+        formatted_start_time = start_time.isoformat()
+        formatted_end_time = end_time.isoformat()
+
+        return {
+            'Experiment name': flag_key,
+            'Variant name': variant.variant_key,
+            '$experiment_type': 'feature_flag',
+            "Flag evaluation mode": "remote",
+            "Variant fetch start time": formatted_start_time,
+            "Variant fetch complete time": formatted_end_time,
+            "Variant fetch latency (ms)": request_duration.total_seconds() * 1000,
+        }
+
+    def _handle_response(self, flag_key: str, fallback_value: SelectedVariant, response: httpx.Response) -> tuple[SelectedVariant, bool]:
         response.raise_for_status()
 
         flags_response = RemoteFlagsResponse.model_validate(response.json())
 
         if flag_key in flags_response.flags:
-            selected_variant = flags_response.flags[flag_key]
-
-            additional_properties = {
-                "Flag evaluation mode": "remote",
-                "Variant fetch start time": formatted_start_time,
-                "Variant fetch complete time": formatted_end_time,
-                "Variant fetch latency (ms)": request_duration.total_seconds() * 1000,
-            }
-
-            if distinct_id := context.get("distinct_id"):
-                track_exposure_event(
-                    distinct_id=distinct_id,
-                    flag_key=flag_key,
-                    variant=selected_variant,
-                    additional_properties=additional_properties,
-                    tracker=self._tracker)
-
-            return selected_variant
+            return flags_response.flags[flag_key], False
         else:
             logging.warning(f"Flag {flag_key} not found in remote response. Returning fallback, {fallback_value}")
-            return fallback_value
+            return fallback_value, True
 
     def __enter__(self):
         return self
@@ -117,8 +138,8 @@ class RemoteFeatureFlagsProvider:
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         logging.info("Exiting the RemoteFeatureFlagsProvider and cleaning up resources")
-        self.sync_client.close()
+        self._sync_client.close()
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         logging.info("Exiting the RemoteFeatureFlagsProvider and cleaning up resources")
-        await self.async_client.aclose()
+        await self._async_client.aclose()

--- a/mixpanel/flags/remote_feature_flags.py
+++ b/mixpanel/flags/remote_feature_flags.py
@@ -28,11 +28,11 @@ class RemoteFeatureFlagsProvider:
         self.async_client: httpx.AsyncClient = httpx.AsyncClient(**httpx_client_parameters)
         self.sync_client: httpx.Client = httpx.Client(**httpx_client_parameters)
 
-    async def get_variant_value(self, flag_key: str, fallback_value: str, context: Dict[str, str]) -> SelectedVariant:
-        variant = await self.get_variant(flag_key, SelectedVariant(variant_key=fallback_value, variant_value=fallback_value), context)
+    async def aget_variant_value(self, flag_key: str, fallback_value: str, context: Dict[str, str]) -> SelectedVariant:
+        variant = await self.aget_variant(flag_key, SelectedVariant(variant_key=fallback_value, variant_value=fallback_value), context)
         return variant.variant_value
 
-    async def get_variant(self, flag_key: str, fallback_value: SelectedVariant, context: Dict[str, str]) -> SelectedVariant:
+    async def aget_variant(self, flag_key: str, fallback_value: SelectedVariant, context: Dict[str, str]) -> SelectedVariant:
         try:
             params = self._prepare_query_params(flag_key, context)
             start_time = datetime.now()
@@ -43,15 +43,15 @@ class RemoteFeatureFlagsProvider:
             logging.exception(f"Failed to get remote variant for flag {flag_key}")
             return fallback_value
 
-    async def is_enabled(self, flag_key: str, context: Dict[str, str]) -> bool:
-        variant = await self.get_variant_value(flag_key, "false", context)
+    async def ais_enabled(self, flag_key: str, context: Dict[str, str]) -> bool:
+        variant = await self.aget_variant_value(flag_key, "false", context)
         return bool(variant.variant_value)
 
-    def get_variant_value_sync(self, flag_key: str, fallback_value: Any, context: Dict[str, str]) -> SelectedVariant:
-        variant = self.get_variant_sync(flag_key, SelectedVariant(variant_key=fallback_value, variant_value=fallback_value), context)
+    def get_variant_value(self, flag_key: str, fallback_value: Any, context: Dict[str, str]) -> SelectedVariant:
+        variant = self.get_variant(flag_key, SelectedVariant(variant_key=fallback_value, variant_value=fallback_value), context)
         return variant.variant_value
 
-    def get_variant_sync(self, flag_key: str, fallback_value: SelectedVariant, context: Dict[str, str]) -> SelectedVariant:
+    def get_variant(self, flag_key: str, fallback_value: SelectedVariant, context: Dict[str, str]) -> SelectedVariant:
         try:
             params = self._prepare_query_params(flag_key, context)
             start_time = datetime.now()
@@ -62,8 +62,8 @@ class RemoteFeatureFlagsProvider:
             logging.exception(f"Failed to get remote variant for flag {flag_key}")
             return fallback_value
 
-    def is_enabled_sync(self, flag_key: str, context: Dict[str, str]) -> bool:
-        variant = self.get_variant_value_sync(flag_key, "false", context)
+    def is_enabled(self, flag_key: str, context: Dict[str, str]) -> bool:
+        variant = self.get_variant_value(flag_key, "false", context)
         return bool(variant.variant_value)
 
     def _prepare_query_params(self, flag_key: str, context: Dict[str, str]) -> Dict[str, str]:

--- a/mixpanel/flags/remote_feature_flags.py
+++ b/mixpanel/flags/remote_feature_flags.py
@@ -8,6 +8,9 @@ from typing import Dict, Any, Callable
 from .types import RemoteFlagsConfig, SelectedVariant, RemoteFlagsResponse
 from .utils import REQUEST_HEADERS, track_exposure_event
 
+logger = logging.getLogger(__name__)
+logging.getLogger("httpx").setLevel(logging.ERROR)
+
 class RemoteFeatureFlagsProvider:
     FLAGS_URL_PATH = "/flags"
 

--- a/mixpanel/flags/remote_feature_flags.py
+++ b/mixpanel/flags/remote_feature_flags.py
@@ -36,7 +36,7 @@ class RemoteFeatureFlagsProvider:
         self._request_params_base = prepare_common_query_params(self._token, version)
 
     async def aget_variant_value(self, flag_key: str, fallback_value: Any, context: Dict[str, Any]) -> Any:
-        variant = await self.aget_variant(flag_key, SelectedVariant(variant_key=fallback_value, variant_value=fallback_value), context)
+        variant = await self.aget_variant(flag_key, SelectedVariant(variant_value=fallback_value), context)
         return variant.variant_value
 
     async def aget_variant(self, flag_key: str, fallback_value: SelectedVariant, context: Dict[str, Any]) -> SelectedVariant:
@@ -55,15 +55,15 @@ class RemoteFeatureFlagsProvider:
 
             return selected_variant
         except Exception:
-            logging.exception(f"Failed to get remote variant for flag {flag_key}")
+            logging.exception(f"Failed to get remote variant for flag '{flag_key}'")
             return fallback_value
 
     async def ais_enabled(self, flag_key: str, context: Dict[str, Any]) -> bool:
-        variant = await self.aget_variant_value(flag_key, "false", context)
-        return bool(variant.variant_value)
+        variant_value = await self.aget_variant_value(flag_key, False, context)
+        return bool(variant_value)
 
     def get_variant_value(self, flag_key: str, fallback_value: Any, context: Dict[str, Any]) -> Any:
-        variant = self.get_variant(flag_key, SelectedVariant(variant_key=fallback_value, variant_value=fallback_value), context)
+        variant = self.get_variant(flag_key, SelectedVariant(variant_value=fallback_value), context)
         return variant.variant_value
 
     def get_variant(self, flag_key: str, fallback_value: SelectedVariant, context: Dict[str, Any]) -> SelectedVariant:
@@ -81,12 +81,12 @@ class RemoteFeatureFlagsProvider:
 
             return selected_variant
         except Exception:
-            logging.exception(f"Failed to get remote variant for flag {flag_key}")
+            logging.exception(f"Failed to get remote variant for flag '{flag_key}'")
             return fallback_value
 
     def is_enabled(self, flag_key: str, context: Dict[str, Any]) -> bool:
-        variant = self.get_variant_value(flag_key, "false", context)
-        return bool(variant.variant_value)
+        variant_value = self.get_variant_value(flag_key, False, context)
+        return bool(variant_value)
 
     def _prepare_query_params(self, flag_key: str, context: Dict[str, Any]) -> Dict[str, str]:
         params = self._request_params_base.copy()
@@ -102,7 +102,7 @@ class RemoteFeatureFlagsProvider:
         request_duration = end_time - start_time
         formatted_start_time = start_time.isoformat()
         formatted_end_time = end_time.isoformat()
-        logging.info(f"Request started at {formatted_start_time}, completed at {formatted_end_time}, duration: {request_duration.total_seconds():.3f}s")
+        logging.info(f"Request started at '{formatted_start_time}', completed at '{formatted_end_time}', duration: '{request_duration.total_seconds():.3f}s'")
 
     def _build_tracking_properties(self, flag_key: str, variant: SelectedVariant, start_time: datetime, end_time: datetime) -> Dict[str, Any]:
         request_duration = end_time - start_time
@@ -127,7 +127,7 @@ class RemoteFeatureFlagsProvider:
         if flag_key in flags_response.flags:
             return flags_response.flags[flag_key], False
         else:
-            logging.warning(f"Flag {flag_key} not found in remote response. Returning fallback, {fallback_value}")
+            logging.warning(f"Flag '{flag_key}' not found in remote response. Returning fallback, '{fallback_value}'")
             return fallback_value, True
 
     def __enter__(self):

--- a/mixpanel/flags/remote_feature_flags.py
+++ b/mixpanel/flags/remote_feature_flags.py
@@ -1,0 +1,119 @@
+import httpx
+import logging
+import json
+import urllib.parse
+from datetime import datetime, timedelta
+from typing import Dict, Any, Callable
+
+from .types import RemoteFlagsConfig, SelectedVariant, RemoteFlagsResponse
+from .utils import REQUEST_HEADERS, track_exposure_event
+
+class RemoteFeatureFlagsProvider:
+    FLAGS_URL_PATH = "/flags"
+
+    def __init__(self, token: str, config: RemoteFlagsConfig, tracker: Callable) -> None:
+        self._config: RemoteFlagsConfig = config
+        self._tracker: Callable = tracker
+
+        httpx_client_parameters = {
+            "base_url": f"https://{config.api_host}",
+            "headers": REQUEST_HEADERS,
+            "auth": httpx.BasicAuth(token, ""),
+            "timeout": httpx.Timeout(config.requestTimeoutInSeconds),
+        }
+
+        self.async_client: httpx.AsyncClient = httpx.AsyncClient(**httpx_client_parameters)
+        self.sync_client: httpx.Client = httpx.Client(**httpx_client_parameters)
+
+    async def get_variant_value(self, flag_key: str, fallback_value: str, context: Dict[str, str]) -> SelectedVariant:
+        variant = await self.get_variant(flag_key, SelectedVariant(variant_key=fallback_value, variant_value=fallback_value), context)
+        return variant.variant_value
+
+    async def get_variant(self, flag_key: str, fallback_value: SelectedVariant, context: Dict[str, str]) -> SelectedVariant:
+        try:
+            params = self._prepare_query_params(flag_key, context)
+            start_time = datetime.now()
+            response = await self.async_client.get(self.FLAGS_URL_PATH, params=params)
+            end_time = datetime.now()
+            return self._handle_response(context, flag_key, fallback_value, response, start_time, end_time)
+        except Exception:
+            logging.exception(f"Failed to get remote variant for flag {flag_key}")
+            return fallback_value
+
+    async def is_enabled(self, flag_key: str, context: Dict[str, str]) -> bool:
+        variant = await self.get_variant_value(flag_key, "false", context)
+        return bool(variant.variant_value)
+
+    def get_variant_value_sync(self, flag_key: str, fallback_value: Any, context: Dict[str, str]) -> SelectedVariant:
+        variant = self.get_variant_sync(flag_key, SelectedVariant(variant_key=fallback_value, variant_value=fallback_value), context)
+        return variant.variant_value
+
+    def get_variant_sync(self, flag_key: str, fallback_value: SelectedVariant, context: Dict[str, str]) -> SelectedVariant:
+        try:
+            params = self._prepare_query_params(flag_key, context)
+            start_time = datetime.now()
+            response = self.sync_client.get(self.FLAGS_URL_PATH, params=params)
+            end_time = datetime.now()
+            return self._handle_response(context, flag_key, fallback_value, response, start_time, end_time)
+        except Exception:
+            logging.exception(f"Failed to get remote variant for flag {flag_key}")
+            return fallback_value
+
+    def is_enabled_sync(self, flag_key: str, context: Dict[str, str]) -> bool:
+        variant = self.get_variant_value_sync(flag_key, "false", context)
+        return bool(variant.variant_value)
+
+    def _prepare_query_params(self, flag_key: str, context: Dict[str, str]) -> Dict[str, str]:
+        context_json = json.dumps(context).encode('utf-8')
+        url_encoded_context = urllib.parse.quote(context_json)
+        params = {
+            'flag_key': flag_key,
+            "context": url_encoded_context
+        }
+        return params
+
+    def _handle_response(self, context: Dict[str, str], flag_key: str, fallback_value: SelectedVariant, response: httpx.Response, start_time: datetime, end_time: datetime) -> SelectedVariant:
+        request_duration: timedelta = (end_time - start_time)
+        formatted_start_time, formatted_end_time = start_time.isoformat(), end_time.isoformat()
+        logging.info(f"Request started at {formatted_start_time}, completed at {formatted_end_time}, duration: {request_duration.total_seconds():.3f}s")
+
+        response.raise_for_status()
+
+        flags_response = RemoteFlagsResponse.model_validate(response.json())
+
+        if flag_key in flags_response.flags:
+            selected_variant = flags_response.flags[flag_key]
+
+            additional_properties = {
+                "Flag evaluation mode": "remote",
+                "Variant fetch start time": formatted_start_time,
+                "Variant fetch complete time": formatted_end_time,
+                "Variant fetch latency (ms)": request_duration.total_seconds() * 1000,
+            }
+
+            if distinct_id := context.get("distinct_id"):
+                track_exposure_event(
+                    distinct_id=distinct_id,
+                    flag_key=flag_key,
+                    variant=selected_variant,
+                    additional_properties=additional_properties,
+                    tracker=self._tracker)
+
+            return selected_variant
+        else:
+            logging.warning(f"Flag {flag_key} not found in remote response. Returning fallback, {fallback_value}")
+            return fallback_value
+
+    def __enter__(self):
+        return self
+
+    async def __aenter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        logging.info("Exiting the RemoteFeatureFlagsProvider and cleaning up resources")
+        self.sync_client.close()
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        logging.info("Exiting the RemoteFeatureFlagsProvider and cleaning up resources")
+        await self.async_client.aclose()

--- a/mixpanel/flags/test_local_feature_flags.py
+++ b/mixpanel/flags/test_local_feature_flags.py
@@ -16,7 +16,7 @@ class TestLocalFeatureFlagsProvider:
         config.enablePolling = False
         mock_tracker = Mock()
         flags_provider = LocalFeatureFlagsProvider("test-token", config, mock_tracker)
-        await flags_provider.start_polling_for_definitions()
+        await flags_provider.astart_polling_for_definitions()
         return flags_provider
 
     @staticmethod

--- a/mixpanel/flags/test_local_feature_flags.py
+++ b/mixpanel/flags/test_local_feature_flags.py
@@ -158,10 +158,8 @@ class TestLocalFeatureFlagsProvider:
             }
         }
 
-        with patch('mixpanel.flags.utils.normalized_hash') as mock_hash:
-            mock_hash.return_value = 0.5
-            result = flags.get_variant_value("test_flag", "fallback", context)
-            assert result != "fallback"
+        result = flags.get_variant_value("test_flag", "fallback", context)
+        assert result != "fallback"
 
     @respx.mock
     async def test_get_variant_value_returns_fallback_when_runtime_evaluation_not_satisfied(self):

--- a/mixpanel/flags/test_local_feature_flags.py
+++ b/mixpanel/flags/test_local_feature_flags.py
@@ -227,12 +227,14 @@ class TestLocalFeatureFlagsProviderAsync:
         with patch('mixpanel.flags.utils.normalized_hash') as mock_hash:
             mock_hash.return_value = 0.5
             _ = flags.get_variant_value("test_flag", "fallback", {"distinct_id": "user123"})
+            flags._executor.shutdown()
             flags._tracker.assert_called_once()
 
     @respx.mock
     async def test_get_variant_value_does_not_track_exposure_on_fallback(self):
         flags = await self.setup_flags([])
         _ = flags.get_variant_value("nonexistent_flag", "fallback", {"distinct_id": "user123"})
+        flags._executor.shutdown()
         flags._tracker.assert_not_called()
 
     @respx.mock
@@ -240,6 +242,7 @@ class TestLocalFeatureFlagsProviderAsync:
         flag = create_test_flag(context="company")
         flags = await self.setup_flags([flag])
         _ = flags.get_variant_value("nonexistent_flag", "fallback", {"company_id": "company123"})
+        flags._executor.shutdown()
         flags._tracker.assert_not_called()
 
     @respx.mock
@@ -283,7 +286,6 @@ class TestLocalFeatureFlagsProviderAsync:
 
             flags_in_order=[[flag_v1], [flag_v2]]
             flags = await self.setup_flags_with_polling(flags_in_order)
-
             async with polling_limit_check:
                 await polling_limit_check.wait_for(lambda: polling_iterations >= len(flags_in_order))
 

--- a/mixpanel/flags/test_local_feature_flags.py
+++ b/mixpanel/flags/test_local_feature_flags.py
@@ -1,0 +1,211 @@
+import pytest
+import respx
+import httpx
+from unittest.mock import Mock, patch
+from typing import Dict
+from .types import LocalFlagsConfig, ExperimentationFlag, RuleSet, Variant, Rollout, FlagTestUsers, ExperimentationFlags
+from .local_feature_flags import LocalFeatureFlagsProvider
+
+@pytest.mark.asyncio
+class TestLocalFeatureFlagsProvider:
+    async def setup_flags(self, flags):
+        respx.get("https://api.mixpanel.com/flags/definitions").mock(
+            return_value=self.create_flags_response(flags))
+
+        config = LocalFlagsConfig()
+        config.enablePolling = False
+        mock_tracker = Mock()
+        flags_provider = LocalFeatureFlagsProvider("test-token", config, mock_tracker)
+        await flags_provider.start_polling_for_definitions()
+        return flags_provider
+
+    @staticmethod
+    def create_test_flag(
+        flag_key: str = "test_flag",
+        context: str = "distinct_id", 
+        variants: list = None,
+        rollout_percentage: float = 100.0,
+        runtime_evaluation: Dict = None,
+        test_users: Dict[str, str] = None) -> ExperimentationFlag:
+
+        if variants is None:
+            variants = [
+                Variant(key="control", value="control", is_control=True, split=50.0),
+                Variant(key="treatment", value="treatment", is_control=False, split=50.0)
+            ]
+
+        rollouts = [Rollout(
+            rollout_percentage=rollout_percentage,
+            runtime_evaluation_definition=runtime_evaluation,
+            variant_override=None
+        )]
+
+        test_config = None
+        if test_users:
+            test_config = FlagTestUsers(users=test_users)
+
+        ruleset = RuleSet(
+            variants=variants,
+            rollout=rollouts,
+            test=test_config
+        )
+
+        return ExperimentationFlag(
+            id="test-id",
+            name="Test Flag",
+            key=flag_key,
+            status="active",
+            project_id=123,
+            ruleset=ruleset,
+            context=context
+        )
+
+    def create_flags_response(self, flags: list = None) -> Dict:
+        if flags is None:
+            flags = []
+        response_data = ExperimentationFlags(flags=flags).model_dump()
+        return httpx.Response(status_code=200, json=response_data)
+
+    @respx.mock
+    async def test_get_variant_value_returns_fallback_when_no_flag_definitions(self):
+        flags = await self.setup_flags([])
+        result = flags.get_variant_value("nonexistent_flag", "control", {"distinct_id": "user123"})
+        assert result == "control"
+
+    @respx.mock
+    async def test_get_variant_value_returns_fallback_when_flag_does_not_exist(self):
+        other_flag = self.create_test_flag("other_flag")
+        flags = await self.setup_flags([other_flag])
+        
+        result = flags.get_variant_value("nonexistent_flag", "control", {"distinct_id": "user123"})
+        assert result == "control"
+
+    @respx.mock
+    async def test_get_variant_value_returns_fallback_when_no_context(self):
+        flag = self.create_test_flag(context="distinct_id")
+        flags = await self.setup_flags([flag])
+        
+        result = flags.get_variant_value("test_flag", "fallback", {})
+        assert result == "fallback"
+
+    @respx.mock
+    async def test_get_variant_value_returns_fallback_when_wrong_context_key(self):
+        flag = self.create_test_flag(context="user_id")
+        flags = await self.setup_flags([flag])
+        
+        result = flags.get_variant_value("test_flag", "fallback", {"distinct_id": "user123"})
+        assert result == "fallback"
+
+    @respx.mock
+    async def test_get_variant_value_returns_test_user_variant_when_configured(self):
+        variants = [
+            Variant(key="control", value="false", is_control=True, split=50.0),
+            Variant(key="treatment", value="true", is_control=False, split=50.0)
+        ]
+        flag = self.create_test_flag(
+            variants=variants,
+            test_users={"test_user": "treatment"}
+        )
+
+        flags = await self.setup_flags([flag])
+
+        result = flags.get_variant_value("test_flag", "control", {"distinct_id": "test_user"})
+
+        assert result == "true"
+
+    @respx.mock
+    async def test_get_variant_value_returns_fallback_when_test_user_variant_not_configured(self):
+        variants = [
+            Variant(key="control", value="false", is_control=True, split=50.0),
+            Variant(key="treatment", value="true", is_control=False, split=50.0)
+        ]
+        flag = self.create_test_flag(
+            variants=variants,
+            test_users={"test_user": "nonexistent_variant"}
+        )
+        flags = await self.setup_flags([flag])
+
+        with patch('mixpanel.flags.utils.normalized_hash') as mock_hash:
+            mock_hash.return_value = 0.5
+            result = flags.get_variant_value("test_flag", "fallback", {"distinct_id": "test_user"})
+            assert result == "false"
+
+    @respx.mock
+    async def test_get_variant_value_returns_fallback_when_rollout_percentage_zero(self):
+        flag = self.create_test_flag(rollout_percentage=0.0)
+        flags = await self.setup_flags([flag])
+
+        result = flags.get_variant_value("test_flag", "fallback", {"distinct_id": "user123"})
+        assert result == "fallback"
+
+    @respx.mock
+    async def test_get_variant_value_returns_variant_when_rollout_percentage_hundred(self):
+        flag = self.create_test_flag(rollout_percentage=100.0)
+        flags = await self.setup_flags([flag])
+        result = flags.get_variant_value("test_flag", "fallback", {"distinct_id": "user123"})
+        assert result != "fallback"
+
+    @respx.mock
+    async def test_get_variant_value_respects_runtime_evaluation_satisfied(self):
+        runtime_eval = {"plan": "premium", "region": "US"}
+        flag = self.create_test_flag(runtime_evaluation=runtime_eval)
+        flags = await self.setup_flags([flag])
+        context = {
+            "distinct_id": "user123",
+            "custom_properties": {
+                "plan": "premium",
+                "region": "US"
+            }
+        }
+
+        with patch('mixpanel.flags.utils.normalized_hash') as mock_hash:
+            mock_hash.return_value = 0.5
+            result = flags.get_variant_value("test_flag", "fallback", context)
+            assert result != "fallback"
+
+    @respx.mock
+    async def test_get_variant_value_returns_fallback_when_runtime_evaluation_not_satisfied(self):
+        runtime_eval = {"plan": "premium", "region": "US"}
+        flag = self.create_test_flag(runtime_evaluation=runtime_eval)
+        flags = await self.setup_flags([flag])
+
+        context = {
+            "distinct_id": "user123",
+            "custom_properties": {
+                "plan": "basic",
+                "region": "US"
+            }
+        }
+        
+        result = flags.get_variant_value("test_flag", "fallback", context)
+        assert result == "fallback"
+
+    @respx.mock
+    async def test_get_variant_value_picks_correct_variant_with_hundred_percent_split(self):
+        variants = [
+            Variant(key="A", value="variant_a", is_control=False, split=100.0),
+            Variant(key="B", value="variant_b", is_control=False, split=0.0),
+            Variant(key="C", value="variant_c", is_control=False, split=0.0)
+        ]
+        flag = self.create_test_flag(variants=variants, rollout_percentage=100.0)
+        flags = await self.setup_flags([flag])
+
+        result = flags.get_variant_value("test_flag", "fallback", {"distinct_id": "user123"})
+        assert result == "variant_a"
+
+    @respx.mock
+    async def test_get_variant_value_tracks_exposure_when_variant_selected(self):
+        flag = self.create_test_flag()
+        flags = await self.setup_flags([flag])
+        
+        with patch('mixpanel.flags.utils.normalized_hash') as mock_hash:
+            mock_hash.return_value = 0.5
+            _ = flags.get_variant_value("test_flag", "fallback", {"distinct_id": "user123"})
+            flags._tracker.assert_called_once()
+
+    @respx.mock
+    async def test_get_variant_value_does_not_track_exposure_on_fallback(self):
+        flags = await self.setup_flags([])
+        _ = flags.get_variant_value("nonexistent_flag", "fallback", {"distinct_id": "user123"})
+
+        flags._tracker.assert_not_called()

--- a/mixpanel/flags/test_local_feature_flags.py
+++ b/mixpanel/flags/test_local_feature_flags.py
@@ -1,70 +1,89 @@
+import asyncio
 import pytest
 import respx
 import httpx
+import threading
 from unittest.mock import Mock, patch
-from typing import Dict, Optional
-from .types import LocalFlagsConfig, ExperimentationFlag, RuleSet, Variant, Rollout, FlagTestUsers, ExperimentationFlags
+from typing import Dict, Optional, List
+from itertools import chain, repeat
+from .types import LocalFlagsConfig, ExperimentationFlag, RuleSet, Variant, Rollout, FlagTestUsers, ExperimentationFlags, VariantOverride
 from .local_feature_flags import LocalFeatureFlagsProvider
 
-@pytest.mark.asyncio
-class TestLocalFeatureFlagsProvider:
-    async def setup_flags(self, flags):
-        respx.get("https://api.mixpanel.com/flags/definitions").mock(
-            return_value=self.create_flags_response(flags))
+def create_test_flag(
+    flag_key: str = "test_flag",
+    context: str = "distinct_id",
+    variants: Optional[list[Variant]] = None,
+    variant_override: Optional[VariantOverride] = None,
+    rollout_percentage: float = 100.0,
+    runtime_evaluation: Optional[Dict] = None,
+    test_users: Optional[Dict[str, str]] = None) -> ExperimentationFlag:
 
-        config = LocalFlagsConfig()
-        config.enable_polling = False
+    if variants is None:
+        variants = [
+            Variant(key="control", value="control", is_control=True, split=50.0),
+            Variant(key="treatment", value="treatment", is_control=False, split=50.0)
+        ]
+
+    rollouts = [Rollout(
+        rollout_percentage=rollout_percentage,
+        runtime_evaluation_definition=runtime_evaluation,
+        variant_override=variant_override
+    )]
+
+    test_config = None
+    if test_users:
+        test_config = FlagTestUsers(users=test_users)
+
+    ruleset = RuleSet(
+        variants=variants,
+        rollout=rollouts,
+        test=test_config
+    )
+
+    return ExperimentationFlag(
+        id="test-id",
+        name="Test Flag",
+        key=flag_key,
+        status="active",
+        project_id=123,
+        ruleset=ruleset,
+        context=context
+    )
+
+
+def create_flags_response(flags: List[ExperimentationFlag]) -> httpx.Response:
+    if flags is None:
+        flags = []
+    response_data = ExperimentationFlags(flags=flags).model_dump()
+    return httpx.Response(status_code=200, json=response_data)
+
+
+@pytest.mark.asyncio
+class TestLocalFeatureFlagsProviderAsync:
+    async def get_flags_provider(self, config: LocalFlagsConfig) -> LocalFeatureFlagsProvider:
         mock_tracker = Mock()
         flags_provider = LocalFeatureFlagsProvider("test-token", config, "1.0.0", mock_tracker)
         await flags_provider.astart_polling_for_definitions()
         return flags_provider
 
-    @staticmethod
-    def create_test_flag(
-        flag_key: str = "test_flag",
-        context: str = "distinct_id", 
-        variants: Optional[list]= None,
-        rollout_percentage: float = 100.0,
-        runtime_evaluation: Optional[Dict] = None,
-        test_users: Optional[Dict[str, str]] = None) -> ExperimentationFlag:
+    async def setup_flags(self, flags: List[ExperimentationFlag]):
+        respx.get("https://api.mixpanel.com/flags/definitions").mock(
+            return_value=create_flags_response(flags))
 
-        if variants is None:
-            variants = [
-                Variant(key="control", value="control", is_control=True, split=50.0),
-                Variant(key="treatment", value="treatment", is_control=False, split=50.0)
-            ]
+        return await self.get_flags_provider(LocalFlagsConfig(enable_polling=False))
 
-        rollouts = [Rollout(
-            rollout_percentage=rollout_percentage,
-            runtime_evaluation_definition=runtime_evaluation,
-            variant_override=None
-        )]
+    async def setup_flags_with_polling(self, flags_in_order: List[List[ExperimentationFlag]] = [[]]):
+        responses = [create_flags_response(flag) for flag in flags_in_order]
 
-        test_config = None
-        if test_users:
-            test_config = FlagTestUsers(users=test_users)
-
-        ruleset = RuleSet(
-            variants=variants,
-            rollout=rollouts,
-            test=test_config
+        respx.get("https://api.mixpanel.com/flags/definitions").mock(
+            side_effect=chain(
+                responses,
+                repeat(responses[-1]),
+            )
         )
 
-        return ExperimentationFlag(
-            id="test-id",
-            name="Test Flag",
-            key=flag_key,
-            status="active",
-            project_id=123,
-            ruleset=ruleset,
-            context=context
-        )
+        return await self.get_flags_provider(LocalFlagsConfig(enable_polling=True, polling_interval_in_seconds=0))
 
-    def create_flags_response(self, flags: list) -> httpx.Response:
-        if flags is None:
-            flags = []
-        response_data = ExperimentationFlags(flags=flags).model_dump()
-        return httpx.Response(status_code=200, json=response_data)
 
     @respx.mock
     async def test_get_variant_value_returns_fallback_when_no_flag_definitions(self):
@@ -73,22 +92,32 @@ class TestLocalFeatureFlagsProvider:
         assert result == "control"
 
     @respx.mock
+    async def test_get_variant_value_returns_fallback_if_flag_definition_call_fails(self):
+        respx.get("https://api.mixpanel.com/flags/definitions").mock(
+            return_value=httpx.Response(status_code=500)
+        )
+
+        flags = await self.get_flags_provider(LocalFlagsConfig(enable_polling=False))
+        result = flags.get_variant_value("nonexistent_flag", "control", {"distinct_id": "user123"})
+        assert result == "control"
+
+    @respx.mock
     async def test_get_variant_value_returns_fallback_when_flag_does_not_exist(self):
-        other_flag = self.create_test_flag("other_flag")
+        other_flag = create_test_flag("other_flag")
         flags = await self.setup_flags([other_flag])
         result = flags.get_variant_value("nonexistent_flag", "control", {"distinct_id": "user123"})
         assert result == "control"
 
     @respx.mock
     async def test_get_variant_value_returns_fallback_when_no_context(self):
-        flag = self.create_test_flag(context="distinct_id")
+        flag = create_test_flag(context="distinct_id")
         flags = await self.setup_flags([flag])
         result = flags.get_variant_value("test_flag", "fallback", {})
         assert result == "fallback"
 
     @respx.mock
     async def test_get_variant_value_returns_fallback_when_wrong_context_key(self):
-        flag = self.create_test_flag(context="user_id")
+        flag = create_test_flag(context="user_id")
         flags = await self.setup_flags([flag])
         result = flags.get_variant_value("test_flag", "fallback", {"distinct_id": "user123"})
         assert result == "fallback"
@@ -99,15 +128,13 @@ class TestLocalFeatureFlagsProvider:
             Variant(key="control", value="false", is_control=True, split=50.0),
             Variant(key="treatment", value="true", is_control=False, split=50.0)
         ]
-        flag = self.create_test_flag(
+        flag = create_test_flag(
             variants=variants,
             test_users={"test_user": "treatment"}
         )
 
         flags = await self.setup_flags([flag])
-
         result = flags.get_variant_value("test_flag", "control", {"distinct_id": "test_user"})
-
         assert result == "true"
 
     @respx.mock
@@ -116,12 +143,11 @@ class TestLocalFeatureFlagsProvider:
             Variant(key="control", value="false", is_control=True, split=50.0),
             Variant(key="treatment", value="true", is_control=False, split=50.0)
         ]
-        flag = self.create_test_flag(
+        flag = create_test_flag(
             variants=variants,
             test_users={"test_user": "nonexistent_variant"}
         )
         flags = await self.setup_flags([flag])
-
         with patch('mixpanel.flags.utils.normalized_hash') as mock_hash:
             mock_hash.return_value = 0.5
             result = flags.get_variant_value("test_flag", "fallback", {"distinct_id": "test_user"})
@@ -129,15 +155,14 @@ class TestLocalFeatureFlagsProvider:
 
     @respx.mock
     async def test_get_variant_value_returns_fallback_when_rollout_percentage_zero(self):
-        flag = self.create_test_flag(rollout_percentage=0.0)
+        flag = create_test_flag(rollout_percentage=0.0)
         flags = await self.setup_flags([flag])
-
         result = flags.get_variant_value("test_flag", "fallback", {"distinct_id": "user123"})
         assert result == "fallback"
 
     @respx.mock
     async def test_get_variant_value_returns_variant_when_rollout_percentage_hundred(self):
-        flag = self.create_test_flag(rollout_percentage=100.0)
+        flag = create_test_flag(rollout_percentage=100.0)
         flags = await self.setup_flags([flag])
         result = flags.get_variant_value("test_flag", "fallback", {"distinct_id": "user123"})
         assert result != "fallback"
@@ -145,7 +170,7 @@ class TestLocalFeatureFlagsProvider:
     @respx.mock
     async def test_get_variant_value_respects_runtime_evaluation_satisfied(self):
         runtime_eval = {"plan": "premium", "region": "US"}
-        flag = self.create_test_flag(runtime_evaluation=runtime_eval)
+        flag = create_test_flag(runtime_evaluation=runtime_eval)
         flags = await self.setup_flags([flag])
         context = {
             "distinct_id": "user123",
@@ -154,16 +179,14 @@ class TestLocalFeatureFlagsProvider:
                 "region": "US"
             }
         }
-
         result = flags.get_variant_value("test_flag", "fallback", context)
         assert result != "fallback"
 
     @respx.mock
     async def test_get_variant_value_returns_fallback_when_runtime_evaluation_not_satisfied(self):
         runtime_eval = {"plan": "premium", "region": "US"}
-        flag = self.create_test_flag(runtime_evaluation=runtime_eval)
+        flag = create_test_flag(runtime_evaluation=runtime_eval)
         flags = await self.setup_flags([flag])
-
         context = {
             "distinct_id": "user123",
             "custom_properties": {
@@ -171,7 +194,6 @@ class TestLocalFeatureFlagsProvider:
                 "region": "US"
             }
         }
-
         result = flags.get_variant_value("test_flag", "fallback", context)
         assert result == "fallback"
 
@@ -182,15 +204,25 @@ class TestLocalFeatureFlagsProvider:
             Variant(key="B", value="variant_b", is_control=False, split=0.0),
             Variant(key="C", value="variant_c", is_control=False, split=0.0)
         ]
-        flag = self.create_test_flag(variants=variants, rollout_percentage=100.0)
+        flag = create_test_flag(variants=variants, rollout_percentage=100.0)
         flags = await self.setup_flags([flag])
-
         result = flags.get_variant_value("test_flag", "fallback", {"distinct_id": "user123"})
         assert result == "variant_a"
 
     @respx.mock
+    async def test_get_variant_value_picks_overriden_variant(self):
+        variants = [
+            Variant(key="A", value="variant_a", is_control=False, split=100.0),
+            Variant(key="B", value="variant_b", is_control=False, split=0.0),
+        ]
+        flag = create_test_flag(variants=variants, variant_override=VariantOverride(key="B"))
+        flags = await self.setup_flags([flag])
+        result = flags.get_variant_value("test_flag", "control", {"distinct_id": "user123"})
+        assert result == "variant_b"
+
+    @respx.mock
     async def test_get_variant_value_tracks_exposure_when_variant_selected(self):
-        flag = self.create_test_flag()
+        flag = create_test_flag()
         flags = await self.setup_flags([flag])
         with patch('mixpanel.flags.utils.normalized_hash') as mock_hash:
             mock_hash.return_value = 0.5
@@ -201,5 +233,107 @@ class TestLocalFeatureFlagsProvider:
     async def test_get_variant_value_does_not_track_exposure_on_fallback(self):
         flags = await self.setup_flags([])
         _ = flags.get_variant_value("nonexistent_flag", "fallback", {"distinct_id": "user123"})
-
         flags._tracker.assert_not_called()
+
+    @respx.mock
+    async def test_get_variant_value_does_not_track_exposure_without_distinct_id(self):
+        flag = create_test_flag(context="company")
+        flags = await self.setup_flags([flag])
+        _ = flags.get_variant_value("nonexistent_flag", "fallback", {"company_id": "company123"})
+        flags._tracker.assert_not_called()
+
+    @respx.mock
+    async def test_are_flags_ready_returns_true_when_flags_loaded(self):
+        flag = create_test_flag()
+        flags = await self.setup_flags([flag])
+        assert flags.are_flags_ready() == True
+
+    @respx.mock
+    async def test_is_enabled_returns_false_for_nonexistent_flag(self):
+        flags = await self.setup_flags([])
+        result = flags.is_enabled("nonexistent_flag", {"distinct_id": "user123"})
+        assert result == False
+
+    @respx.mock
+    async def test_is_enabled_returns_true_for_true_variant_value(self):
+        variants = [
+            Variant(key="treatment", value=True, is_control=False, split=100.0)
+        ]
+        flag = create_test_flag(variants=variants, rollout_percentage=100.0)
+        flags = await self.setup_flags([flag])
+        result = flags.is_enabled("test_flag", {"distinct_id": "user123"})
+        assert result == True
+
+    @respx.mock
+    async def test_get_variant_value_uses_most_recent_polled_flag(self):
+        polling_iterations = 0
+        polling_limit_check = asyncio.Condition()
+        original_fetch = LocalFeatureFlagsProvider._afetch_flag_definitions
+
+        async def track_fetch_calls(self):
+            nonlocal polling_iterations
+            async with polling_limit_check:
+                polling_iterations += 1
+                polling_limit_check.notify_all()
+            return await original_fetch(self)
+
+        with patch.object(LocalFeatureFlagsProvider, '_afetch_flag_definitions', track_fetch_calls):
+            flag_v1 = create_test_flag(rollout_percentage=0.0)
+            flag_v2 = create_test_flag(rollout_percentage=100.0)
+
+            flags_in_order=[[flag_v1], [flag_v2]]
+            flags = await self.setup_flags_with_polling(flags_in_order)
+            result1 = flags.get_variant_value("test_flag", "fallback", {"distinct_id": "user123"})
+
+            assert result1 == "fallback"
+
+            async with polling_limit_check:
+                await polling_limit_check.wait_for(lambda: polling_iterations >= len(flags_in_order))
+
+            result2 = flags.get_variant_value("test_flag", "fallback", {"distinct_id": "user123"})
+            assert result2 != "fallback"
+
+            await flags.astop_polling_for_definitions()
+
+class TestLocalFeatureFlagsProviderSync:
+    def setup_method(self):
+        config = LocalFlagsConfig(enable_polling=True, polling_interval_in_seconds=0)
+        self.mock_tracker = Mock()
+        self._flags = LocalFeatureFlagsProvider("test-token", config, "1.0.0", self.mock_tracker)
+        self._flags.start_polling_for_definitions()
+
+    def teardown_method(self):
+        self._flags.__exit__(None, None, None)
+
+    @respx.mock
+    def test_get_variant_value_uses_most_recent_polled_flag(self):
+        polling_iterations = 0
+        polling_event = threading.Event()
+        original_fetch = LocalFeatureFlagsProvider._fetch_flag_definitions
+
+        # Hook into the fetch method to signal when we've polled multiple times.
+        def track_fetch_calls(provider_self):
+            nonlocal polling_iterations
+            polling_iterations += 1
+            if polling_iterations >= 2:
+                polling_event.set()
+            return original_fetch(provider_self)
+
+        flag_v1 = create_test_flag(rollout_percentage=0.0)
+        flag_v2 = create_test_flag(rollout_percentage=100.0)
+
+        responses = [create_flags_response([flag_v1]), create_flags_response([flag_v2])]
+
+        respx.get("https://api.mixpanel.com/flags/definitions").mock(
+            side_effect=chain(responses, repeat(responses[-1]))
+        )
+
+        with patch.object(LocalFeatureFlagsProvider, '_fetch_flag_definitions', track_fetch_calls):
+            result1 = self._flags.get_variant_value("test_flag", "fallback", {"distinct_id": "user123"})
+            assert result1 == "fallback"
+
+            polling_event.wait(timeout=5.0)
+            self._flags.stop_polling_for_definitions()
+
+            result2 = self._flags.get_variant_value("test_flag", "fallback", {"distinct_id": "user123"})
+            assert result2 != "fallback"

--- a/mixpanel/flags/test_remote_feature_flags.py
+++ b/mixpanel/flags/test_remote_feature_flags.py
@@ -4,7 +4,7 @@ import respx
 import asyncio
 from typing import Dict
 from unittest.mock import Mock
-from .types import RemoteFlagsConfig, ExperimentationFlags, RemoteFlagsResponse, SelectedVariant
+from .types import RemoteFlagsConfig, RemoteFlagsResponse, SelectedVariant
 from .remote_feature_flags import RemoteFeatureFlagsProvider
 
 ENDPOINT = "https://api.mixpanel.com/flags"

--- a/mixpanel/flags/test_remote_feature_flags.py
+++ b/mixpanel/flags/test_remote_feature_flags.py
@@ -64,12 +64,14 @@ class TestRemoteFeatureFlagsProviderAsync:
         if pending:
             await asyncio.gather(*pending, return_exceptions=True)
 
+        self._flags._executor.shutdown()
         self.mock_tracker.assert_called_once()
 
     @respx.mock
     async def test_get_variant_value_does_not_track_exposure_event_if_fallback(self): 
         respx.get(ENDPOINT).mock(side_effect=httpx.RequestError("Network error"))
         await self._flags.aget_variant_value("test_flag", "control", {"distinct_id": "user123"})
+        self._flags._executor.shutdown()
         self.mock_tracker.assert_not_called()
 
     @respx.mock
@@ -133,13 +135,14 @@ class TestRemoteFeatureFlagsProviderSync:
             return_value=create_success_response({"test_flag": SelectedVariant(variant_key="treatment", variant_value="treatment")}))
 
         self._flags.get_variant_value("test_flag", "control", {"distinct_id": "user123"})
+        self._flags._executor.shutdown()
         self.mock_tracker.assert_called_once()
 
     @respx.mock
     def test_get_variant_value_does_not_track_exposure_event_if_fallback(self):
         respx.get(ENDPOINT).mock(side_effect=httpx.RequestError("Network error"))
-        
         self._flags.get_variant_value("test_flag", "control", {"distinct_id": "user123"})
+        self._flags._executor.shutdown()
         self.mock_tracker.assert_not_called()
 
     @respx.mock

--- a/mixpanel/flags/test_remote_feature_flags.py
+++ b/mixpanel/flags/test_remote_feature_flags.py
@@ -1,0 +1,72 @@
+import pytest
+import httpx
+import respx
+from typing import Dict
+from unittest.mock import Mock
+from .types import RemoteFlagsConfig, ExperimentationFlags, RemoteFlagsResponse, SelectedVariant
+from .remote_feature_flags import RemoteFeatureFlagsProvider
+
+ENDPOINT = "https://api.mixpanel.com/flags"
+
+@pytest.mark.asyncio
+class TestRemoteFeatureFlagsProvider:
+    def setup_method(self):
+        config = RemoteFlagsConfig()
+        mock_tracker = Mock()
+        self._flags = RemoteFeatureFlagsProvider("test-token", config, mock_tracker)
+
+    @staticmethod
+    def create_success_response(assignedVariantsPerFlag: Dict[str, SelectedVariant]) -> Dict:
+        serialized_response = RemoteFlagsResponse(code=200, flags=assignedVariantsPerFlag).model_dump()
+        return httpx.Response(status_code=200, json=serialized_response)
+
+    @respx.mock
+    async def test_get_variant_value_is_fallback_if_call_fails(self):
+        respx.get(ENDPOINT).mock(side_effect=httpx.RequestError("Network error"))
+
+        result = await self._flags.get_variant_value("test_flag", "control", {"distinct_id": "user123"})
+
+        assert result == "control" 
+
+    @respx.mock
+    async def test_get_variant_value_is_fallback_if_bad_response_format(self):
+        respx.get(ENDPOINT).mock(return_value=httpx.Response(200, text="invalid json"))
+
+        result = await self._flags.get_variant_value("test_flag", "control", {"distinct_id": "user123"})
+
+        assert result == "control"
+
+    @respx.mock
+    async def test_get_variant_value_is_fallback_if_success_but_no_flag_found(self):
+        respx.get(ENDPOINT).mock(
+            return_value=self.create_success_response({}))
+
+        result = await self._flags.get_variant_value("test_flag", "control", {"distinct_id": "user123"})
+
+        assert result == "control"
+
+    @respx.mock
+    async def test_get_variant_value_returns_expected_variant_from_api(self):
+        respx.get(ENDPOINT).mock(
+            return_value=self.create_success_response({"test_flag": SelectedVariant(variant_key="treatment", variant_value="treatment")}))
+
+        result = await self._flags.get_variant_value("test_flag", "control", {"distinct_id": "user123"})
+
+        assert result == "treatment"
+
+    @respx.mock
+    async def test_get_variant_value_tracks_exposure_event_if_variant_selected(self):
+        respx.get(ENDPOINT).mock(
+            return_value=self.create_success_response({"test_flag": SelectedVariant(variant_key="treatment", variant_value="treatment")}))
+
+        await self._flags.get_variant_value("test_flag", "control", {"distinct_id": "user123"})
+
+        self._flags._tracker.assert_called_once()
+
+    @respx.mock
+    async def test_get_variant_value_does_not_track_exposure_event_if_fallback(self): 
+        respx.get(ENDPOINT).mock(side_effect=httpx.RequestError("Network error"))
+
+        await self._flags.get_variant_value("test_flag", "control", {"distinct_id": "user123"})
+
+        self._flags._tracker.assert_not_called()

--- a/mixpanel/flags/test_remote_feature_flags.py
+++ b/mixpanel/flags/test_remote_feature_flags.py
@@ -24,7 +24,7 @@ class TestRemoteFeatureFlagsProvider:
     async def test_get_variant_value_is_fallback_if_call_fails(self):
         respx.get(ENDPOINT).mock(side_effect=httpx.RequestError("Network error"))
 
-        result = await self._flags.get_variant_value("test_flag", "control", {"distinct_id": "user123"})
+        result = await self._flags.aget_variant_value("test_flag", "control", {"distinct_id": "user123"})
 
         assert result == "control" 
 
@@ -32,7 +32,7 @@ class TestRemoteFeatureFlagsProvider:
     async def test_get_variant_value_is_fallback_if_bad_response_format(self):
         respx.get(ENDPOINT).mock(return_value=httpx.Response(200, text="invalid json"))
 
-        result = await self._flags.get_variant_value("test_flag", "control", {"distinct_id": "user123"})
+        result = await self._flags.aget_variant_value("test_flag", "control", {"distinct_id": "user123"})
 
         assert result == "control"
 
@@ -41,7 +41,7 @@ class TestRemoteFeatureFlagsProvider:
         respx.get(ENDPOINT).mock(
             return_value=self.create_success_response({}))
 
-        result = await self._flags.get_variant_value("test_flag", "control", {"distinct_id": "user123"})
+        result = await self._flags.aget_variant_value("test_flag", "control", {"distinct_id": "user123"})
 
         assert result == "control"
 
@@ -50,7 +50,7 @@ class TestRemoteFeatureFlagsProvider:
         respx.get(ENDPOINT).mock(
             return_value=self.create_success_response({"test_flag": SelectedVariant(variant_key="treatment", variant_value="treatment")}))
 
-        result = await self._flags.get_variant_value("test_flag", "control", {"distinct_id": "user123"})
+        result = await self._flags.aget_variant_value("test_flag", "control", {"distinct_id": "user123"})
 
         assert result == "treatment"
 
@@ -59,7 +59,7 @@ class TestRemoteFeatureFlagsProvider:
         respx.get(ENDPOINT).mock(
             return_value=self.create_success_response({"test_flag": SelectedVariant(variant_key="treatment", variant_value="treatment")}))
 
-        await self._flags.get_variant_value("test_flag", "control", {"distinct_id": "user123"})
+        await self._flags.aget_variant_value("test_flag", "control", {"distinct_id": "user123"})
 
         self._flags._tracker.assert_called_once()
 
@@ -67,6 +67,6 @@ class TestRemoteFeatureFlagsProvider:
     async def test_get_variant_value_does_not_track_exposure_event_if_fallback(self): 
         respx.get(ENDPOINT).mock(side_effect=httpx.RequestError("Network error"))
 
-        await self._flags.get_variant_value("test_flag", "control", {"distinct_id": "user123"})
+        await self._flags.aget_variant_value("test_flag", "control", {"distinct_id": "user123"})
 
         self._flags._tracker.assert_not_called()

--- a/mixpanel/flags/types.py
+++ b/mixpanel/flags/types.py
@@ -1,16 +1,21 @@
 from typing import Optional, List, Dict, Any
-from pydantic import BaseModel
+from concurrent.futures import ThreadPoolExecutor
+from pydantic import BaseModel, ConfigDict
 
 MIXPANEL_DEFAULT_API_ENDPOINT = "api.mixpanel.com"
+
 class FlagsConfig(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
     api_host: str = "api.mixpanel.com"
-    requestTimeoutInSeconds: int = 10
-    retryLimit: int = 3
-    retryExponentialBackoffFactor: int = 1
+    request_timeout_in_seconds: int = 10
+    retry_limit: int = 3
+    retry_exponential_backoff_factor: int = 1
+    custom_executor: Optional[ThreadPoolExecutor] = None
 
 class LocalFlagsConfig(FlagsConfig):
-    enablePolling: bool = True
-    pollingIntervalInSeconds: int = 60
+    enable_polling: bool = True
+    polling_interval_in_seconds: int = 60
 
 class RemoteFlagsConfig(FlagsConfig):
     pass
@@ -29,12 +34,12 @@ class VariantOverride(BaseModel):
 
 class Rollout(BaseModel):
     rollout_percentage: float
-    runtime_evaluation_definition: Optional[Dict[str, Any]] = None
+    runtime_evaluation_definition: Optional[Dict[str, str]] = None
     variant_override: Optional[VariantOverride] = None
 
 class RuleSet(BaseModel):
     variants: List[Variant]
-    rollout: List[Rollout] 
+    rollout: List[Rollout]
     test: Optional[FlagTestUsers] = None
 
 class ExperimentationFlag(BaseModel):
@@ -48,7 +53,7 @@ class ExperimentationFlag(BaseModel):
 
 class SelectedVariant(BaseModel):
     variant_key: str
-    variant_value: str
+    variant_value: Any
 
 class ExperimentationFlags(BaseModel):
     flags: List[ExperimentationFlag] 

--- a/mixpanel/flags/types.py
+++ b/mixpanel/flags/types.py
@@ -1,0 +1,58 @@
+from typing import Optional, List, Dict, Any
+from pydantic import BaseModel
+
+MIXPANEL_DEFAULT_API_ENDPOINT = "api.mixpanel.com"
+class FlagsConfig(BaseModel):
+    api_host: str = "api.mixpanel.com"
+    requestTimeoutInSeconds: int = 10
+    retryLimit: int = 3
+    retryExponentialBackoffFactor: int = 1
+
+class LocalFlagsConfig(FlagsConfig):
+    enablePolling: bool = True
+    pollingIntervalInSeconds: int = 60
+
+class RemoteFlagsConfig(FlagsConfig):
+    pass
+
+class Variant(BaseModel):
+    key: str
+    value: str
+    is_control: bool
+    split: float
+
+class FlagTestUsers(BaseModel):
+    users: Dict[str, str]
+
+class VariantOverride(BaseModel):
+    key: str
+
+class Rollout(BaseModel):
+    rollout_percentage: float
+    runtime_evaluation_definition: Optional[Dict[str, Any]] = None
+    variant_override: Optional[VariantOverride] = None
+
+class RuleSet(BaseModel):
+    variants: List[Variant]
+    rollout: List[Rollout] 
+    test: Optional[FlagTestUsers] = None
+
+class ExperimentationFlag(BaseModel):
+    id: str
+    name: str
+    key: str 
+    status: str
+    project_id: int
+    ruleset: RuleSet 
+    context: str
+
+class SelectedVariant(BaseModel):
+    variant_key: str
+    variant_value: str
+
+class ExperimentationFlags(BaseModel):
+    flags: List[ExperimentationFlag] 
+
+class RemoteFlagsResponse(BaseModel):
+    code: int
+    flags: Dict[str, SelectedVariant]

--- a/mixpanel/flags/types.py
+++ b/mixpanel/flags/types.py
@@ -9,8 +9,6 @@ class FlagsConfig(BaseModel):
 
     api_host: str = "api.mixpanel.com"
     request_timeout_in_seconds: int = 10
-    retry_limit: int = 3
-    retry_exponential_backoff_factor: int = 1
     custom_executor: Optional[ThreadPoolExecutor] = None
 
 class LocalFlagsConfig(FlagsConfig):
@@ -22,7 +20,7 @@ class RemoteFlagsConfig(FlagsConfig):
 
 class Variant(BaseModel):
     key: str
-    value: str
+    value: Any
     is_control: bool
     split: float
 
@@ -52,7 +50,8 @@ class ExperimentationFlag(BaseModel):
     context: str
 
 class SelectedVariant(BaseModel):
-    variant_key: str
+    # variant_key can be None if being used as a fallback
+    variant_key: Optional[str] = None
     variant_value: Any
 
 class ExperimentationFlags(BaseModel):

--- a/mixpanel/flags/utils.py
+++ b/mixpanel/flags/utils.py
@@ -1,36 +1,13 @@
 from typing import Dict
 from .types import SelectedVariant
 
+EXPOSURE_EVENT = "$experiment_started"
+
 REQUEST_HEADERS: Dict[str, str] = {
     'X-Scheme': 'https',
     'X-Forwarded-Proto': 'https',
     'Content-Type': 'application/json'
 }
-
-def track_exposure_event(
-    distinct_id: str,
-    flag_key: str,
-    variant: SelectedVariant,
-    additional_properties: Dict[str, str],
-    tracker) -> None:
-    """Tracks an experiment started event to Mixpanel
-
-    :param distinct_id: The distinct ID of the user being tracked
-    :param flag: The experimentation flag being tracked.
-    :param variant: The selected variant for the experiment
-    :param additional_properties: Additional properties to include in the event
-    :param tracker: The tracker function to use for sending the event
-    """
-
-    properties = {
-        'Experiment name': flag_key,
-        'Variant name': variant.variant_key,
-        '$experiment_type': 'feature_flag',
-    }
-
-    properties.update(additional_properties)
-
-    tracker(distinct_id, '$experiment_started', properties) 
 
 def normalized_hash(key: str, salt: str) -> float:
     """Compute a normalized hash using FNV-1a algorithm.

--- a/mixpanel/flags/utils.py
+++ b/mixpanel/flags/utils.py
@@ -1,0 +1,59 @@
+from typing import Dict
+from .types import SelectedVariant
+
+REQUEST_HEADERS: Dict[str, str] = {
+    'X-Scheme': 'https',
+    'X-Forwarded-Proto': 'https',
+    'Content-Type': 'application/json'
+}
+
+def track_exposure_event(
+    distinct_id: str,
+    flag_key: str,
+    variant: SelectedVariant,
+    additional_properties: Dict[str, str],
+    tracker) -> None:
+    """Tracks an experiment started event to Mixpanel
+
+    :param distinct_id: The distinct ID of the user being tracked
+    :param flag: The experimentation flag being tracked.
+    :param variant: The selected variant for the experiment
+    :param additional_properties: Additional properties to include in the event
+    :param tracker: The tracker function to use for sending the event
+    """
+
+    properties = {
+        'Experiment name': flag_key,
+        'Variant name': variant.variant_key,
+        '$experiment_type': 'feature_flag',
+    }
+
+    properties.update(additional_properties)
+
+    tracker(distinct_id, '$experiment_started', properties) 
+
+def normalized_hash(key: str, salt: str) -> float:
+    """Compute a normalized hash using FNV-1a algorithm.
+    
+    :param key: The key to hash
+    :param salt: Salt to add to the hash
+    :return: Normalized hash value between 0.0 and 1.0
+    """
+    hash_value = _fnv1a64(key.encode("utf-8") + salt.encode("utf-8"))
+    return (hash_value % 100) / 100.0
+
+def _fnv1a64(data: bytes) -> int:
+    """FNV-1a 64-bit hash function.
+    
+    :param data: Bytes to hash
+    :return: 64-bit hash value
+    """
+    FNV_prime = 0x100000001b3
+    hash_value = 0xcbf29ce484222325
+
+    for byte in data:
+        hash_value ^= byte
+        hash_value *= FNV_prime
+        hash_value &= 0xffffffffffffffff  # Keep it 64-bit
+
+    return hash_value

--- a/mixpanel/flags/utils.py
+++ b/mixpanel/flags/utils.py
@@ -1,5 +1,4 @@
 from typing import Dict
-from .types import SelectedVariant
 
 EXPOSURE_EVENT = "$experiment_started"
 
@@ -11,7 +10,7 @@ REQUEST_HEADERS: Dict[str, str] = {
 
 def normalized_hash(key: str, salt: str) -> float:
     """Compute a normalized hash using FNV-1a algorithm.
-    
+
     :param key: The key to hash
     :param salt: Salt to add to the hash
     :return: Normalized hash value between 0.0 and 1.0
@@ -21,7 +20,7 @@ def normalized_hash(key: str, salt: str) -> float:
 
 def _fnv1a64(data: bytes) -> int:
     """FNV-1a 64-bit hash function.
-    
+
     :param data: Bytes to hash
     :return: 64-bit hash value
     """
@@ -43,8 +42,8 @@ def prepare_common_query_params(token: str, sdk_version: str) -> Dict[str, str]:
     :return: Dictionary of common query parameters
     """
     params = {
-        'sdk': 'python',
-        'sdk_version': sdk_version,
+        'mp_lib': 'python',
+        'lib_version': sdk_version,
         'token': token
     }
 

--- a/mixpanel/flags/utils.py
+++ b/mixpanel/flags/utils.py
@@ -57,3 +57,18 @@ def _fnv1a64(data: bytes) -> int:
         hash_value &= 0xffffffffffffffff  # Keep it 64-bit
 
     return hash_value
+
+def prepare_common_query_params(token: str, sdk_version: str) -> Dict[str, str]:
+    """Prepare common query string parameters for feature flag evaluation.
+
+    :param token: The project token
+    :param sdk_version: The SDK version
+    :return: Dictionary of common query parameters
+    """
+    params = {
+        'sdk': 'python',
+        'sdk_version': sdk_version,
+        'token': token
+    }
+
+    return params

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "requests>=2.32.5",
+    "requests>=2.4.2, <3",
     "httpx>=0.27.0",
     "pydantic>=2.0.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "requests>=2.4.2, <3",
     "httpx>=0.27.0",
     "pydantic>=2.0.0",
+    "asgiref>=3.0.0",
 ]
 keywords = ["mixpanel", "analytics"]
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ test = [
     "pytest-asyncio>=0.23.0",
     "responses>=0.25.8",
     "respx>=0.21.0",
+    "coverage"
 ]
 dev = [
     "tox>=4.28.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,9 @@ authors = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "requests>=2.4.2, <3",
+    "requests>=2.32.5",
+    "httpx>=0.27.0",
+    "pydantic>=2.0.0",
 ]
 keywords = ["mixpanel", "analytics"]
 classifiers = [
@@ -32,7 +34,9 @@ Homepage = "https://github.com/mixpanel/mixpanel-python"
 [project.optional-dependencies]
 test = [
     "pytest>=8.4.1",
+    "pytest-asyncio>=0.23.0",
     "responses>=0.25.8",
+    "respx>=0.21.0",
 ]
 dev = [
     "tox>=4.28.4",
@@ -56,3 +60,6 @@ extras = ["test"]
 commands = [
   ["pytest", "{posargs}"],
 ]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ test = [
     "pytest-asyncio>=0.23.0",
     "responses>=0.25.8",
     "respx>=0.21.0",
-    "coverage"
+    "pytest-cov"
 ]
 dev = [
     "tox>=4.28.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ version = {attr = "mixpanel.__version__"}
 exclude = ["demo"]
 
 [tool.tox]
-envlist = ["py39", "py310", "py311", "py312"]
+envlist = ["py39", "py310", "py311", "py312", "pypy39", "pypy311"]
 
 [tool.tox.env_run_base]
 extras = ["test"]


### PR DESCRIPTION
This change introduces a first pass at implement server-side SDK for feature flags.

It introduces two modes for evaluating feature flags, Remote Evaluation and Local Evaluation. The API contract was kept as close to the client SDKs' as it made sense to. See demo.py for some sample usage. I'd love feedback on the API ergonomics

**Remote Evaluation**
Provides methods, get_variant_value, get_variant, is_enabled  more, aligning the API to the client SDK's  as close as it made sense to. Each method makes an outbound call to the flag service for evaluation.

**Local Evaluation**
 Flag Definitions are polled from the server and stored on the SDK. Assignment is run by the SDK itself.
