### PR TITLE
Remove stray `docs/conf.py` from wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dev = [
 version = {attr = "mixpanel.__version__"}
 
 [tool.setuptools.packages.find]
-exclude = ["demo"]
+exclude = ["demo", "docs"]
 
 [tool.tox]
 envlist = ["py39", "py310", "py311", "py312"]


### PR DESCRIPTION
Including `docs/conf.py` in a wheel pollutes the global namespace with a bogus `docs.conf` module and causes conflicts with other packages that do the same.

<img width="1376" height="748" alt="image" src="https://github.com/user-attachments/assets/3a3c54cc-f4b4-43d6-a575-e9ef864218ac" />

This PR excludes `docs` to prevent this.
