### PR TITLE
Pin beta, don't use greater than on it

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "httpx>=0.27.0",
     "pydantic>=2.0.0",
     "asgiref>=3.0.0",
-    "json-logic>=0.7.0a0"
+    "json-logic==0.7.0a0"
 ]
 keywords = ["mixpanel", "analytics"]
 classifiers = [


### PR DESCRIPTION
When using pre-releases, its better practice and can avoid some build tooling complaints.