### PR TITLE
chore: standardize release process

### DIFF
--- a/.github/modules.json
+++ b/.github/modules.json
@@ -1,0 +1,18 @@
+{
+  "analytics": {
+    "tag_prefix": "v",
+    "pyproject_toml": "pyproject.toml",
+    "version_files": ["mixpanel/__init__.py"],
+    "changelog": "CHANGELOG.md",
+    "readme": "README.md",
+    "package_name": "mixpanel"
+  },
+  "openfeature": {
+    "tag_prefix": "openfeature/v",
+    "pyproject_toml": "openfeature-provider/pyproject.toml",
+    "version_files": [],
+    "changelog": "openfeature-provider/CHANGELOG.md",
+    "readme": "openfeature-provider/README.md",
+    "package_name": "mixpanel-openfeature"
+  }
+}

--- a/.github/scripts/generate-changelog.sh
+++ b/.github/scripts/generate-changelog.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+set -euo pipefail
+
+MODULE="$1"
+VERSION_LABEL="$2"
+REPO_URL="$3"
+END_REF="${4:-HEAD}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+MODULES_JSON="$SCRIPT_DIR/../modules.json"
+
+TAG_PREFIX=$(jq -e -r --arg m "$MODULE" '.[$m].tag_prefix' "$MODULES_JSON") || {
+  echo "Unknown module: $MODULE. Valid modules: $(jq -r 'keys | join(", ")' "$MODULES_JSON")" >&2
+  exit 1
+}
+TAG_GLOB="${TAG_PREFIX}*"
+
+PREVIOUS_TAG=$(git tag --sort=-creatordate --list "$TAG_GLOB" | head -1 || true)
+
+if [ -z "$PREVIOUS_TAG" ]; then
+  RANGE="$END_REF"
+else
+  RANGE="${PREVIOUS_TAG}..${END_REF}"
+fi
+
+DATE=$(date +%Y-%m-%d)
+SAFE_URL=$(printf '%s' "$REPO_URL" | sed 's|[&/\]|\\&|g')
+
+declare -a FEATURES=()
+declare -a FIXES=()
+declare -a CHORES=()
+
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+  MSG=$(echo "$line" | cut -d' ' -f2-)
+
+  if [[ "$MSG" =~ ^(feat|fix|chore)\((${MODULE}|all)\):\ (.+) ]]; then
+    TYPE="${BASH_REMATCH[1]}"
+    DESC="${BASH_REMATCH[3]}"
+
+    DESC=$(echo "$DESC" | sed -E "s|\(#([0-9]+)\)|([#\1](${SAFE_URL}/pull/\1))|g")
+
+    case "$TYPE" in
+      feat) FEATURES+=("$DESC") ;;
+      fix) FIXES+=("$DESC") ;;
+      chore) CHORES+=("$DESC") ;;
+    esac
+  fi
+done < <(git log --oneline "$RANGE")
+
+echo "## [${VERSION_LABEL}](${REPO_URL}/tree/${VERSION_LABEL}) (${DATE})"
+echo ""
+
+if [ ${#FEATURES[@]} -gt 0 ]; then
+  echo "### Features"
+  for entry in "${FEATURES[@]}"; do
+    echo "- ${entry}"
+  done
+  echo ""
+fi
+
+if [ ${#FIXES[@]} -gt 0 ]; then
+  echo "### Fixes"
+  for entry in "${FIXES[@]}"; do
+    echo "- ${entry}"
+  done
+  echo ""
+fi
+
+if [ ${#CHORES[@]} -gt 0 ]; then
+  echo "### Chores"
+  for entry in "${CHORES[@]}"; do
+    echo "- ${entry}"
+  done
+  echo ""
+fi
+
+if [ -n "$PREVIOUS_TAG" ]; then
+  echo "[Full Changelog](${REPO_URL}/compare/${PREVIOUS_TAG}...${VERSION_LABEL})"
+fi

--- a/.github/scripts/generate-changelog.sh
+++ b/.github/scripts/generate-changelog.sh
@@ -34,17 +34,24 @@ while IFS= read -r line; do
   [ -z "$line" ] && continue
   MSG=$(echo "$line" | cut -d' ' -f2-)
 
-  if [[ "$MSG" =~ ^(feat|fix|chore)\((${MODULE}|all)\):\ (.+) ]]; then
+  # feat / fix: include whether bare, scoped to our module, or scoped to
+  # `all` (cross-cutting changes that appear in every module's changelog).
+  # chore: include only when explicitly scoped to our module or `all` —
+  # bare `chore:` is the convention for changes intentionally hidden from
+  # the changelog (release prep PRs, CI tweaks, lockfile bumps, internal
+  # docs).
+  if [[ "$MSG" =~ ^(feat|fix)(\((${MODULE}|all)\))?:\ (.+) ]]; then
     TYPE="${BASH_REMATCH[1]}"
-    DESC="${BASH_REMATCH[3]}"
-
+    DESC="${BASH_REMATCH[4]}"
     DESC=$(echo "$DESC" | sed -E "s|\(#([0-9]+)\)|([#\1](${SAFE_URL}/pull/\1))|g")
-
     case "$TYPE" in
       feat) FEATURES+=("$DESC") ;;
       fix) FIXES+=("$DESC") ;;
-      chore) CHORES+=("$DESC") ;;
     esac
+  elif [[ "$MSG" =~ ^chore\((${MODULE}|all)\):\ (.+) ]]; then
+    DESC="${BASH_REMATCH[2]}"
+    DESC=$(echo "$DESC" | sed -E "s|\(#([0-9]+)\)|([#\1](${SAFE_URL}/pull/\1))|g")
+    CHORES+=("$DESC")
   fi
 done < <(git log --oneline "$RANGE")
 

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -23,8 +23,10 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           MODULE_LIST=$(jq -r 'keys | join("|")' .github/modules.json)
-          # Scope is optional. Bare or scoped to a known module both pass.
-          MAIN_PATTERN="^(feat|fix|chore)(\((${MODULE_LIST})\))?: .+"
+          # Scope is optional. Bare, scoped to a known module, or scoped to
+          # `all` (cross-cutting changes that appear in every module's
+          # changelog) all pass.
+          MAIN_PATTERN="^(feat|fix|chore)(\((${MODULE_LIST}|all)\))?: .+"
           RELEASE_PATTERN="^release: .+"
 
           if [[ "$PR_TITLE" =~ $MAIN_PATTERN ]] || [[ "$PR_TITLE" =~ $RELEASE_PATTERN ]]; then
@@ -40,10 +42,10 @@ jobs:
           echo "  feat: description"
           echo "  fix: description"
           echo "  chore: description"
-          echo "  feat(<module>): description"
-          echo "  fix(<module>): description"
-          echo "  chore(<module>): description"
+          echo "  feat(<module>|all): description"
+          echo "  fix(<module>|all): description"
+          echo "  chore(<module>|all): description"
           echo "  release: description"
           echo ""
-          echo "Valid modules: ${MODULE_LIST//|/, }"
+          echo "Valid scopes: ${MODULE_LIST//|/, }, all"
           exit 1

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,0 +1,49 @@
+name: PR Title Check
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  check-title:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          sparse-checkout: .github/modules.json
+          sparse-checkout-cone-mode: false
+
+      - name: Check PR title format
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          MODULE_LIST=$(jq -r 'keys | join("|")' .github/modules.json)
+          # Scope is optional. Bare or scoped to a known module both pass.
+          MAIN_PATTERN="^(feat|fix|chore)(\((${MODULE_LIST})\))?: .+"
+          RELEASE_PATTERN="^release: .+"
+
+          if [[ "$PR_TITLE" =~ $MAIN_PATTERN ]] || [[ "$PR_TITLE" =~ $RELEASE_PATTERN ]]; then
+            echo "PR title is valid: $PR_TITLE"
+            exit 0
+          fi
+
+          echo "PR title does not match the required format."
+          echo ""
+          echo "  Got: $PR_TITLE"
+          echo ""
+          echo "Expected one of:"
+          echo "  feat: description"
+          echo "  fix: description"
+          echo "  chore: description"
+          echo "  feat(<module>): description"
+          echo "  fix(<module>): description"
+          echo "  chore(<module>): description"
+          echo "  release: description"
+          echo ""
+          echo "Valid modules: ${MODULE_LIST//|/, }"
+          exit 1

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -193,10 +193,18 @@ jobs:
           MODULE: ${{ inputs.module }}
           VERSION: ${{ inputs.version }}
           BRANCH: ${{ steps.config.outputs.branch }}
+          PYPROJECT_TOML: ${{ steps.config.outputs.pyproject_toml }}
+          VERSION_FILES: ${{ steps.config.outputs.version_files }}
+          CHANGELOG_FILE: ${{ steps.config.outputs.changelog }}
+          README: ${{ steps.config.outputs.readme }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add -A
+          git add "$PYPROJECT_TOML" "$CHANGELOG_FILE" "$README"
+          while IFS= read -r FILE; do
+            [ -z "$FILE" ] && continue
+            git add "$FILE"
+          done <<< "$VERSION_FILES"
           git commit -m "release: prepare ${MODULE} ${VERSION}"
           git push origin "$BRANCH"
 

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,238 @@
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      module:
+        description: 'Module to release (must match a key in .github/modules.json)'
+        required: true
+        type: string
+      version:
+        description: 'Release version (e.g., 1.3.0 or 1.3.0-beta.1)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: prepare-release-${{ inputs.module }}
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    name: "Prepare ${{ inputs.module }} ${{ inputs.version }}"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Validate inputs
+        env:
+          MODULE: ${{ inputs.module }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            echo "::error::Invalid version format: $VERSION"
+            exit 1
+          fi
+          jq -e --arg m "$MODULE" '.[$m]' .github/modules.json > /dev/null || {
+            echo "::error::Unknown module '$MODULE'. Valid modules: $(jq -r 'keys | join(", ")' .github/modules.json)"
+            exit 1
+          }
+
+      - name: Resolve module config
+        id: config
+        env:
+          MODULE: ${{ inputs.module }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          MODULE_CONFIG=$(jq -e --arg m "$MODULE" '.[$m]' .github/modules.json)
+
+          TAG_PREFIX=$(echo "$MODULE_CONFIG" | jq -r '.tag_prefix')
+          {
+            echo "tag=${TAG_PREFIX}${VERSION}"
+            echo "tag_prefix=${TAG_PREFIX}"
+            echo "pyproject_toml=$(echo "$MODULE_CONFIG" | jq -r '.pyproject_toml')"
+            # Newline-separated list of additional Python source files holding the version literal.
+            echo "version_files<<EOF"
+            echo "$MODULE_CONFIG" | jq -r '.version_files[]?'
+            echo "EOF"
+            echo "changelog=$(echo "$MODULE_CONFIG" | jq -r '.changelog')"
+            echo "readme=$(echo "$MODULE_CONFIG" | jq -r '.readme')"
+            echo "package_name=$(echo "$MODULE_CONFIG" | jq -r '.package_name')"
+            echo "branch=release/${MODULE}/${VERSION}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Validate version not already released
+        env:
+          TAG: ${{ steps.config.outputs.tag }}
+        run: |
+          if git tag -l "$TAG" | grep -q .; then
+            echo "::error::Tag $TAG already exists"
+            exit 1
+          fi
+
+      - name: Clean up existing release branch and PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ steps.config.outputs.branch }}
+        run: |
+          EXISTING_PR=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number' 2>/dev/null || true)
+          if [[ -n "$EXISTING_PR" ]]; then
+            echo "Closing existing PR #$EXISTING_PR and deleting branch"
+            gh pr close "$EXISTING_PR" --delete-branch
+          elif git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            echo "Deleting orphaned branch $BRANCH"
+            git push origin --delete "$BRANCH"
+          fi
+
+      - name: Create release branch
+        env:
+          BRANCH: ${{ steps.config.outputs.branch }}
+        run: git checkout -b "$BRANCH"
+
+      - name: Bump version
+        env:
+          VERSION: ${{ inputs.version }}
+          PYPROJECT_TOML: ${{ steps.config.outputs.pyproject_toml }}
+          VERSION_FILES: ${{ steps.config.outputs.version_files }}
+        run: |
+          set -euo pipefail
+
+          # If pyproject.toml uses dynamic version, the canonical source lives
+          # in the listed Python file(s) (e.g. `__version__ = "X.Y.Z"`). Otherwise
+          # the literal `version = "X.Y.Z"` line in pyproject.toml is the source.
+          IS_DYNAMIC=$(python3 - <<PY
+          import sys
+          try:
+              import tomllib  # py311+
+          except ModuleNotFoundError:
+              import tomli as tomllib
+          with open("${PYPROJECT_TOML}", "rb") as f:
+              data = tomllib.load(f)
+          project = data.get("project", {})
+          dynamic = project.get("dynamic", []) or []
+          print("yes" if "version" in dynamic else "no")
+          PY
+          )
+
+          if [ "$IS_DYNAMIC" = "yes" ]; then
+            echo "pyproject ${PYPROJECT_TOML} declares version dynamically; updating version_files."
+            if [ -z "${VERSION_FILES//[[:space:]]/}" ]; then
+              echo "::error::Module has dynamic version but no version_files entry in modules.json"
+              exit 1
+            fi
+            while IFS= read -r vf; do
+              [ -z "$vf" ] && continue
+              if [ ! -f "$vf" ]; then
+                echo "::error::version_files entry not found: $vf"
+                exit 1
+              fi
+              # Match either `__version__ = "X"` or `__version__ = 'X'`.
+              if ! grep -E "^__version__\s*=\s*['\"][^'\"]+['\"]" "$vf" >/dev/null; then
+                echo "::error::No __version__ literal found in $vf"
+                exit 1
+              fi
+              OLD=$(grep -E "^__version__\s*=\s*['\"][^'\"]+['\"]" "$vf" | head -1 | sed -E "s/.*['\"]([^'\"]+)['\"].*/\1/")
+              echo "Bumping ${vf}: ${OLD} -> ${VERSION}"
+              sed -i.bak -E "s|^__version__[[:space:]]*=[[:space:]]*['\"][^'\"]+['\"]|__version__ = \"${VERSION}\"|" "$vf"
+              rm -f "${vf}.bak"
+            done <<< "$VERSION_FILES"
+          else
+            if ! grep -E "^version[[:space:]]*=[[:space:]]*\"[^\"]+\"" "$PYPROJECT_TOML" >/dev/null; then
+              echo "::error::No literal version line found in $PYPROJECT_TOML"
+              exit 1
+            fi
+            OLD=$(grep -E "^version[[:space:]]*=[[:space:]]*\"[^\"]+\"" "$PYPROJECT_TOML" | head -1 | sed -E "s/.*\"([^\"]+)\".*/\1/")
+            echo "Bumping ${PYPROJECT_TOML}: ${OLD} -> ${VERSION}"
+            sed -i.bak -E "s|^version[[:space:]]*=[[:space:]]*\"[^\"]+\"|version = \"${VERSION}\"|" "$PYPROJECT_TOML"
+            rm -f "${PYPROJECT_TOML}.bak"
+          fi
+
+      - name: Update README version header
+        env:
+          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+          TAG: ${{ steps.config.outputs.tag }}
+          README: ${{ steps.config.outputs.readme }}
+        run: |
+          DATE=$(date +"%B %d, %Y")
+          # The `1,/pat/` address range bounds substitution to the first match
+          # so older changelog entries inside the README aren't trampled.
+          sed -i -E \
+            "1,/^##### _.*_ - \[.*\]\(.*\)\$/ s|^##### _.*_ - \[.*\]\(.*\)\$|##### _${DATE}_ - [${TAG}](${REPO_URL}/releases/tag/${TAG})|" \
+            "$README"
+
+      - name: Generate changelog
+        env:
+          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+          MODULE: ${{ inputs.module }}
+          TAG: ${{ steps.config.outputs.tag }}
+          CHANGELOG_FILE: ${{ steps.config.outputs.changelog }}
+        run: |
+          CHANGELOG=$(.github/scripts/generate-changelog.sh \
+            "$MODULE" "$TAG" "$REPO_URL" HEAD)
+
+          if [ -f "$CHANGELOG_FILE" ]; then
+            {
+              printf '# Changelog\n\n%s\n' "$CHANGELOG"
+              sed '1{/^# Changelog$/d;}' "$CHANGELOG_FILE"
+            } > CHANGELOG.new.md
+            mv CHANGELOG.new.md "$CHANGELOG_FILE"
+          else
+            mkdir -p "$(dirname "$CHANGELOG_FILE")"
+            printf '# Changelog\n\n%s\n' "$CHANGELOG" > "$CHANGELOG_FILE"
+          fi
+
+      - name: Commit and push
+        env:
+          MODULE: ${{ inputs.module }}
+          VERSION: ${{ inputs.version }}
+          BRANCH: ${{ steps.config.outputs.branch }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "release: prepare ${MODULE} ${VERSION}"
+          git push origin "$BRANCH"
+
+      - name: Create pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MODULE: ${{ inputs.module }}
+          VERSION: ${{ inputs.version }}
+          TAG: ${{ steps.config.outputs.tag }}
+          TAG_PREFIX: ${{ steps.config.outputs.tag_prefix }}
+          PYPROJECT_TOML: ${{ steps.config.outputs.pyproject_toml }}
+          CHANGELOG_FILE: ${{ steps.config.outputs.changelog }}
+          README: ${{ steps.config.outputs.readme }}
+          BRANCH: ${{ steps.config.outputs.branch }}
+        run: |
+          gh pr create \
+            --title "release: prepare ${MODULE} ${VERSION}" \
+            --body "$(cat <<EOF
+          ## Release ${MODULE} ${VERSION}
+
+          This PR prepares the ${MODULE} module for release.
+
+          ### Changes
+          - Bumps version to \`${VERSION}\` (in \`${PYPROJECT_TOML}\` and/or its referenced version file)
+          - Updates \`${CHANGELOG_FILE}\` with a new section since the last \`${TAG_PREFIX}*\` tag
+          - Updates \`${README}\` version header
+
+          ### After merging
+          1. Push tag \`${TAG}\` from the merge commit on \`master\` to trigger the publish workflow:
+             \`\`\`
+             git checkout master && git pull
+             git tag ${TAG}
+             git push origin ${TAG}
+             \`\`\`
+          2. The publish workflow creates a draft GitHub release and publishes to PyPI via Trusted Publishing. Review and publish the GitHub release after the workflow finishes.
+          EOF
+          )" \
+            --base master \
+            --head "$BRANCH"

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -1,0 +1,242 @@
+name: Publish Release to PyPI
+
+# Tag-triggered: PyPI Trusted Publishing requires the publish to come from a
+# workflow run triggered by a tag-push matching the patterns configured in the
+# project's PyPI Trusted Publisher entry. Add new tag prefixes here as
+# additional modules are added to .github/modules.json (e.g. `- 'foo-v*'`).
+on:
+  push:
+    tags:
+      - 'v*'
+      - 'openfeature/v*'
+
+concurrency:
+  group: pypi-publish
+  cancel-in-progress: false
+
+permissions:
+  contents: write   # create the draft GitHub release
+  id-token: write   # OIDC for PyPI trusted publishing
+
+jobs:
+  publish:
+    name: "Publish ${{ github.ref_name }} to PyPI"
+    runs-on: ubuntu-latest
+    environment: release
+    timeout-minutes: 30
+
+    # One-time PyPI / GitHub Environment / tag ruleset setup is required.
+    # The `environment:` name above must match what the PyPI project's
+    # Trusted Publisher entry is configured to require.
+
+    steps:
+      - name: Checkout tagged commit
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Resolve module from tag
+        id: module
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          MODULE=$(jq -r --arg t "$TAG" '
+            to_entries
+            | map(select($t | startswith(.value.tag_prefix)))
+            | max_by(.value.tag_prefix | length)
+            | .key // empty
+          ' .github/modules.json)
+
+          if [ -z "$MODULE" ]; then
+            echo "::error::Tag '$TAG' does not match any module tag_prefix in .github/modules.json"
+            exit 1
+          fi
+
+          MODULE_CONFIG=$(jq -e --arg m "$MODULE" '.[$m]' .github/modules.json)
+          TAG_PREFIX=$(echo "$MODULE_CONFIG" | jq -r '.tag_prefix')
+          VERSION="${TAG#${TAG_PREFIX}}"
+
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            echo "::error::Version '$VERSION' (from tag '$TAG') is not a valid semver"
+            exit 1
+          fi
+
+          PYPROJECT_TOML=$(echo "$MODULE_CONFIG" | jq -r '.pyproject_toml')
+          PROJECT_DIR=$(dirname "$PYPROJECT_TOML")
+
+          {
+            echo "module=$MODULE"
+            echo "version=$VERSION"
+            echo "tag_prefix=$TAG_PREFIX"
+            echo "pyproject_toml=$PYPROJECT_TOML"
+            echo "project_dir=$PROJECT_DIR"
+            echo "version_files<<EOF"
+            echo "$MODULE_CONFIG" | jq -r '.version_files[]?'
+            echo "EOF"
+            echo "changelog=$(echo "$MODULE_CONFIG" | jq -r '.changelog')"
+            echo "package_name=$(echo "$MODULE_CONFIG" | jq -r '.package_name')"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "Resolved tag '$TAG' -> module '$MODULE', version '$VERSION', project dir '$PROJECT_DIR'"
+
+      - name: Verify tag commit is on master
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          git fetch origin master
+          TAG_SHA=$(git rev-parse HEAD)
+          if ! git merge-base --is-ancestor "$TAG_SHA" origin/master; then
+            echo "::error::Tag '$TAG' ($TAG_SHA) is not an ancestor of origin/master."
+            echo "Tags must be pushed from a commit on the master branch."
+            exit 1
+          fi
+
+      - name: Validate package version matches tag
+        env:
+          VERSION: ${{ steps.module.outputs.version }}
+          PYPROJECT_TOML: ${{ steps.module.outputs.pyproject_toml }}
+          VERSION_FILES: ${{ steps.module.outputs.version_files }}
+        run: |
+          set -euo pipefail
+          PKG_VERSION=$(python3 - <<PY
+          import os
+          try:
+              import tomllib
+          except ModuleNotFoundError:
+              import tomli as tomllib
+          with open(os.environ["PYPROJECT_TOML"], "rb") as f:
+              data = tomllib.load(f)
+          project = data.get("project", {})
+          dynamic = project.get("dynamic", []) or []
+          if "version" in dynamic:
+              # Read the version literal from the first version_files entry.
+              files = [f for f in os.environ.get("VERSION_FILES", "").splitlines() if f.strip()]
+              if not files:
+                  raise SystemExit("dynamic version but no version_files configured")
+              import re
+              with open(files[0]) as vf:
+                  text = vf.read()
+              m = re.search(r"^__version__\s*=\s*['\"]([^'\"]+)['\"]", text, re.M)
+              if not m:
+                  raise SystemExit(f"no __version__ literal in {files[0]}")
+              print(m.group(1))
+          else:
+              print(project.get("version", ""))
+          PY
+          )
+          if [ "$VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Tag version '$VERSION' does not match package version '$PKG_VERSION'"
+            exit 1
+          fi
+          echo "Version confirmed: $PKG_VERSION"
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: '3.12'
+
+      - name: Install build tooling
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build twine
+
+      - name: Install package and run tests
+        env:
+          MODULE: ${{ steps.module.outputs.module }}
+        run: |
+          python -m pip install -e .[test]
+          if [ "$MODULE" = "openfeature" ]; then
+            python -m pip install -e ./openfeature-provider[test]
+            pytest openfeature-provider/tests/
+          else
+            pytest
+          fi
+
+      - name: Build distribution
+        env:
+          PROJECT_DIR: ${{ steps.module.outputs.project_dir }}
+        run: |
+          set -euo pipefail
+          rm -rf dist
+          # `python -m build` writes to ./dist relative to its working directory.
+          # For sub-projects (openfeature) we cd into the project dir, build,
+          # then move artifacts to a top-level ./dist for the upload step.
+          if [ "$PROJECT_DIR" = "." ]; then
+            python -m build
+          else
+            (cd "$PROJECT_DIR" && python -m build)
+            mkdir -p dist
+            mv "$PROJECT_DIR"/dist/* dist/
+          fi
+          ls -la dist
+
+      - name: Validate distribution
+        run: python -m twine check dist/*
+
+      - name: Extract changelog section for tag
+        env:
+          TAG: ${{ github.ref_name }}
+          CHANGELOG: ${{ steps.module.outputs.changelog }}
+        run: |
+          # Match the section header `## [${TAG}](...)` and stop at the next `## ` header.
+          # Falls back to a placeholder if no matching section is found.
+          python3 - <<'PY' > release_notes.md
+          import os, re, sys
+          tag = os.environ["TAG"]
+          changelog_path = os.environ["CHANGELOG"]
+          try:
+              content = open(changelog_path).read()
+          except FileNotFoundError:
+              print(f"Release {tag}")
+              sys.exit(0)
+          pattern = r'^## \[' + re.escape(tag) + r'\].*?\n(.*?)(?=^## |\Z)'
+          match = re.search(pattern, content, re.DOTALL | re.MULTILINE)
+          if match:
+              print(match.group(1).strip())
+          else:
+              print(f"Release {tag}")
+          PY
+          echo "--- release_notes.md ---"
+          cat release_notes.md
+
+      - name: Create draft GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          # Idempotent: if a draft release for this tag already exists, leave it alone.
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "GitHub release for $TAG already exists; skipping creation"
+          else
+            gh release create "$TAG" \
+              --draft \
+              --title "$TAG" \
+              --notes-file release_notes.md
+          fi
+
+      # Publish last - PyPI uploads are irreversible (releases can be yanked
+      # but not re-uploaded under the same version). The `release` GitHub
+      # Environment's required reviewer acts as the human gate.
+      #
+      # Trusted Publishing: twine >= 5 picks up the GitHub OIDC token
+      # automatically when `id-token: write` is set and no
+      # username/password/token is provided.
+      - name: Publish to PyPI
+        run: python -m twine upload --skip-existing --non-interactive dist/*
+
+      - name: Summary
+        env:
+          MODULE: ${{ steps.module.outputs.module }}
+          VERSION: ${{ steps.module.outputs.version }}
+          PACKAGE_NAME: ${{ steps.module.outputs.package_name }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          {
+            echo "## ${MODULE} ${VERSION} published"
+            echo ""
+            echo "- [PyPI](https://pypi.org/project/${PACKAGE_NAME}/${VERSION}/)"
+            echo "- [Draft GitHub Release](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases/tag/${TAG})"
+            echo ""
+            echo "### Next step"
+            echo "Review the draft GitHub release and click **Publish release** to make it live."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           MODULE=$(jq -r --arg t "$TAG" '
             to_entries
-            | map(select($t | startswith(.value.tag_prefix)))
+            | map(select(.value.tag_prefix as $p | $t | startswith($p)))
             | max_by(.value.tag_prefix | length)
             | .key // empty
           ' .github/modules.json)

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -178,24 +178,20 @@ jobs:
           TAG: ${{ github.ref_name }}
           CHANGELOG: ${{ steps.module.outputs.changelog }}
         run: |
-          # Match the section header `## [${TAG}](...)` and stop at the next `## ` header.
-          # Falls back to a placeholder if no matching section is found.
-          python3 - <<'PY' > release_notes.md
-          import os, re, sys
-          tag = os.environ["TAG"]
-          changelog_path = os.environ["CHANGELOG"]
-          try:
-              content = open(changelog_path).read()
-          except FileNotFoundError:
-              print(f"Release {tag}")
-              sys.exit(0)
-          pattern = r'^## \[' + re.escape(tag) + r'\].*?\n(.*?)(?=^## |\Z)'
-          match = re.search(pattern, content, re.DOTALL | re.MULTILINE)
-          if match:
-              print(match.group(1).strip())
-          else:
-              print(f"Release {tag}")
-          PY
+          # Extract this tag's section from CHANGELOG.md via a sed range.
+          # The address `\@^## \[TAG\]@,\@^## \[@` selects from the version
+          # header through the next `## [` line; the inner block deletes
+          # both markers and prints the body. sed range patterns don't test
+          # the end pattern against the start line, so the start doesn't
+          # self-terminate. `\@...@` switches the address delimiter from
+          # `/` to `@` so tags containing `/` (e.g. `openfeature/v0.1.0`)
+          # don't conflict with the default `/`. Mirrors the deployed
+          # mixpanel-android extraction logic. Falls back to a placeholder
+          # if the section is missing or empty.
+          sed -n '\@^## \['"${TAG}"'\]@,\@^## \[@{\@^## \['"${TAG}"'\]@d;\@^## \[@d;p;}' "$CHANGELOG" 2>/dev/null > release_notes.md || true
+          if [ ! -s release_notes.md ]; then
+            echo "Release $TAG" > release_notes.md
+          fi
           echo "--- release_notes.md ---"
           cat release_notes.md
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+Release notes for the `mixpanel` Python package will be added here starting
+with the first release made under the standardized release process.
+
+For prior history, see [`CHANGES.txt`](./CHANGES.txt).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # mixpanel-python
 
+##### _May 13, 2026_ - [v5.1.0](https://github.com/mixpanel/mixpanel-python/releases/tag/v5.1.0)
+
 [![PyPI](https://img.shields.io/pypi/v/mixpanel)](https://pypi.org/project/mixpanel)
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/mixpanel)](https://pypi.org/project/mixpanel)
 [![PyPI - Downloads](https://img.shields.io/pypi/dm/mixpanel)](https://pypi.org/project/mixpanel)

--- a/openfeature-provider/CHANGELOG.md
+++ b/openfeature-provider/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+Release notes for the `mixpanel-openfeature` package will be added here
+starting with the first release made under the standardized release process.

--- a/openfeature-provider/README.md
+++ b/openfeature-provider/README.md
@@ -1,5 +1,7 @@
 # Mixpanel Python OpenFeature Provider
 
+##### _May 13, 2026_ - [openfeature/v0.1.0](https://github.com/mixpanel/mixpanel-python/releases/tag/openfeature/v0.1.0)
+
 [![PyPI](https://img.shields.io/pypi/v/mixpanel-openfeature.svg)](https://pypi.org/project/mixpanel-openfeature/)
 [![OpenFeature](https://img.shields.io/badge/OpenFeature-compatible-green)](https://openfeature.dev/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/mixpanel/mixpanel-python/blob/master/LICENSE)


### PR DESCRIPTION
## Summary

Standardizes this repo's release process to match the rest of the Mixpanel SDK fleet, per the [SDK Release Process Standardization Effort](https://www.notion.so/mxpnl/SDK-Release-Process-Standardization-Effort-348e0ba925628029af63c779caa835f9).

After merge, releases follow a uniform two-step ceremony:

1. Run the **Prepare Release** workflow (`prepare-release.yml`) — opens a release PR with the version bump, changelog section, and README header line updated.
2. Push the release tag — `release-pypi.yml` validates, gates on the `release` GitHub environment for human approval, and publishes (where applicable for this ecosystem).

## What's added

- `.github/modules.json` — single source of truth for module config (paths, tag prefixes, package names)
- `.github/workflows/prepare-release.yml` — manual dispatch, opens release PR
- `.github/workflows/release-pypi.yml` — tag-triggered publish workflow
- `.github/workflows/pr-title-check.yml` — conventional-commit enforcement (regex built from `modules.json`)
- `.github/scripts/generate-changelog.sh` — shared changelog generator (verbatim from mixpanel-android)
- README version-header line on each module's README, seeded with the current latest tag
- `CHANGELOG.md` per module where missing
- Two modules covered: `analytics` (`mixpanel` on PyPI) and `openfeature` (`mixpanel-openfeature` on PyPI)
- The legacy `CHANGES.txt` is left in place for historical continuity; the new auto-generated section format goes into `CHANGELOG.md`
- PyPI Trusted Publisher entries are required for both packages — see runbook

## How releases work after this lands

Full ceremony, one-time setup, and PR title conventions: **[Python [PIP] Release Runbook](https://www.notion.so/mxpnl/Python-PIP-Release-Runbook-35ee0ba9256280dbbe32c9cc26332bde)**

## One-time setup before the first release

The runbook lists the full setup. The work that requires repo-admin access (cannot be done in this PR):

- Create a GitHub Environment named `release` with required reviewer(s)
- Branch protection on the default branch (require PR review + the new `Validate PR title` check)
- Tag rulesets (restrict creation/update/deletion of release tags)
- Workflow permissions: enable `Read and write permissions` and `Allow GitHub Actions to create and approve pull requests` (needed by `prepare-release.yml`'s `gh pr create`)

## Notes

- This is a **WIP** draft to be reviewed alongside the equivalent PRs in the other SDK repos. The Flutter and React Native ports are tracked at mixpanel-flutter#238, mixpanel-flutter-session-replay#30, mixpanel-react-native#408, mixpanel-react-native-session-replay#64.
- This PR does not change any source code or build behavior — only adds release infrastructure.
- The standardization commit is followed by a small `fix:` commit correcting a jq tag-resolution snippet (the same bug exists in the WIP Flutter/RN PRs and should be back-ported there).