### PR TITLE
Fix double URL-encoding of context param in remote feature flags

### DIFF
--- a/mixpanel/flags/remote_feature_flags.py
+++ b/mixpanel/flags/remote_feature_flags.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-import urllib.parse
 from datetime import datetime
 from typing import Any, Callable
 
@@ -277,9 +276,7 @@ class RemoteFeatureFlagsProvider:
         self, context: dict[str, Any], flag_key: str | None = None
     ) -> dict[str, str]:
         params = self._request_params_base.copy()
-        context_json = json.dumps(context).encode("utf-8")
-        url_encoded_context = urllib.parse.quote(context_json)
-        params["context"] = url_encoded_context
+        params["context"] = json.dumps(context)
         if flag_key is not None:
             params["flag_key"] = flag_key
         return params

--- a/mixpanel/flags/test_remote_feature_flags.py
+++ b/mixpanel/flags/test_remote_feature_flags.py
@@ -201,6 +201,48 @@ class TestRemoteFeatureFlagsProviderAsync:
         self.mock_tracker.assert_called_once()
 
 
+class TestPrepareQueryParams:
+    def setup_method(self):
+        config = RemoteFlagsConfig()
+        self.mock_tracker = Mock()
+        self._flags = RemoteFeatureFlagsProvider(
+            "test-token", config, "1.0.0", self.mock_tracker
+        )
+
+    def teardown_method(self):
+        self._flags.__exit__(None, None, None)
+
+    def test_context_is_json_string_not_url_encoded(self):
+        context = {"distinct_id": "user123", "plan": "premium"}
+        params = self._flags._prepare_query_params(context)
+        assert params["context"] == '{"distinct_id": "user123", "plan": "premium"}'
+
+    def test_context_is_not_bytes(self):
+        context = {"distinct_id": "user123"}
+        params = self._flags._prepare_query_params(context)
+        assert isinstance(params["context"], str)
+
+    def test_flag_key_included_when_provided(self):
+        context = {"distinct_id": "user123"}
+        params = self._flags._prepare_query_params(context, flag_key="my_flag")
+        assert params["flag_key"] == "my_flag"
+
+    def test_flag_key_absent_when_not_provided(self):
+        context = {"distinct_id": "user123"}
+        params = self._flags._prepare_query_params(context)
+        assert "flag_key" not in params
+
+    @respx.mock
+    def test_request_url_has_properly_encoded_context(self):
+        respx.get(ENDPOINT).mock(return_value=create_success_response({}))
+        self._flags.get_all_variants({"distinct_id": "user123"})
+
+        request = respx.calls.last.request
+        url_str = str(request.url)
+        assert "%257B" not in url_str, "context param is double-encoded"
+        assert "b%27" not in url_str, "context param contains bytes literal"
+
+
 class TestRemoteFeatureFlagsProviderSync:
     def setup_method(self):
         config = RemoteFlagsConfig()


### PR DESCRIPTION
## Summary

`RemoteFeatureFlagsProvider._prepare_query_params` manually URL-encodes the JSON context string via `urllib.parse.quote()` before passing it as an httpx query parameter. Since httpx **also** URL-encodes all query parameter values when constructing the request URL, the `context` parameter ends up double-encoded:

| Character | Expected | Actual (double-encoded) |
|-----------|----------|------------------------|
| `{`       | `%7B`    | `%257B`                |
| `"`       | `%22`    | `%2522`                |
| `:`       | `%3A`    | `%253A`                |

This causes the Mixpanel `/flags` API to return **400 Bad Request** because it cannot parse the garbled context.

### Before (broken)

```python
context_json = json.dumps(context).encode("utf-8")
url_encoded_context = urllib.parse.quote(context_json)
params["context"] = url_encoded_context
# httpx then encodes again → %257B%2522distinct_id%2522...
```

### After (fixed)

```python
params["context"] = json.dumps(context)
# httpx handles encoding once → %7B%22distinct_id%22...
```

## Changes

- **`mixpanel/flags/remote_feature_flags.py`**: Remove manual `urllib.parse.quote()` and `.encode("utf-8")` in `_prepare_query_params`. Pass the raw JSON string and let httpx handle URL encoding.
- **`mixpanel/flags/test_remote_feature_flags.py`**: Add `TestPrepareQueryParams` test class covering:
  - Context value is a plain JSON string (not pre-encoded)
  - Context value is `str`, not `bytes`
  - `flag_key` presence/absence
  - End-to-end check that the request URL is not double-encoded

## Test plan

- [x] All 31 existing + new tests pass (`pytest mixpanel/flags/test_remote_feature_flags.py`)
- [x] New `test_request_url_has_properly_encoded_context` asserts no `%257B` (double-encode) or `b%27` (bytes literal) in the outgoing URL
- [x] Verified against live Mixpanel `/flags` API — 400s resolve with this fix applied


Made with [Cursor](https://cursor.com)