### PR TITLE
fix(analytics): distinguish fallback reasons + forward backend error message (SDK-79, SDK-83)

### DIFF
--- a/mixpanel/flags/local_feature_flags.py
+++ b/mixpanel/flags/local_feature_flags.py
@@ -230,7 +230,7 @@ class LocalFeatureFlagsProvider:
 
         if not flag_definition:
             logger.warning("Cannot find flag definition for key: '%s'", flag_key)
-            return fallback_value.as_fallback(FallbackReason.FLAG_NOT_FOUND)
+            return fallback_value.as_fallback(FallbackReason.flag_not_found())
 
         if not (context_value := context.get(flag_definition.context)):
             logger.warning(
@@ -238,7 +238,9 @@ class LocalFeatureFlagsProvider:
                 flag_definition.context,
                 flag_key,
             )
-            return fallback_value.as_fallback(FallbackReason.MISSING_CONTEXT_KEY)
+            return fallback_value.as_fallback(
+                FallbackReason.missing_context_key(flag_definition.context)
+            )
 
         selected_variant: SelectedVariant | None = None
 
@@ -267,7 +269,7 @@ class LocalFeatureFlagsProvider:
             context_value,
             flag_key,
         )
-        return fallback_value.as_fallback(FallbackReason.NO_ROLLOUT_MATCH)
+        return fallback_value.as_fallback(FallbackReason.no_rollout_match())
 
     def track_exposure_event(
         self, flag_key: str, variant: SelectedVariant, context: dict[str, Any]

--- a/mixpanel/flags/local_feature_flags.py
+++ b/mixpanel/flags/local_feature_flags.py
@@ -15,9 +15,11 @@ from mixpanel.credentials import ServiceAccountCredentials
 from .types import (
     ExperimentationFlag,
     ExperimentationFlags,
+    FallbackReason,
     LocalFlagsConfig,
     Rollout,
     SelectedVariant,
+    VariantSource,
 )
 from .utils import (
     EXPOSURE_EVENT,
@@ -228,7 +230,7 @@ class LocalFeatureFlagsProvider:
 
         if not flag_definition:
             logger.warning("Cannot find flag definition for key: '%s'", flag_key)
-            return fallback_value
+            return fallback_value.as_fallback(FallbackReason.FLAG_NOT_FOUND)
 
         if not (context_value := context.get(flag_definition.context)):
             logger.warning(
@@ -236,7 +238,7 @@ class LocalFeatureFlagsProvider:
                 flag_definition.context,
                 flag_key,
             )
-            return fallback_value
+            return fallback_value.as_fallback(FallbackReason.MISSING_CONTEXT_KEY)
 
         selected_variant: SelectedVariant | None = None
 
@@ -257,7 +259,7 @@ class LocalFeatureFlagsProvider:
                 self._track_exposure(
                     flag_key, selected_variant, context, end_time - start_time
                 )
-            return selected_variant
+            return selected_variant.with_source(VariantSource.LOCAL)
 
         logger.debug(
             "%s context %s not eligible for any rollout for flag: %s",
@@ -265,7 +267,7 @@ class LocalFeatureFlagsProvider:
             context_value,
             flag_key,
         )
-        return fallback_value
+        return fallback_value.as_fallback(FallbackReason.NO_ROLLOUT_MATCH)
 
     def track_exposure_event(
         self, flag_key: str, variant: SelectedVariant, context: dict[str, Any]

--- a/mixpanel/flags/remote_feature_flags.py
+++ b/mixpanel/flags/remote_feature_flags.py
@@ -11,7 +11,13 @@ from asgiref.sync import sync_to_async
 
 from mixpanel.credentials import ServiceAccountCredentials
 
-from .types import RemoteFlagsConfig, RemoteFlagsResponse, SelectedVariant
+from .types import (
+    FallbackReason,
+    RemoteFlagsConfig,
+    RemoteFlagsResponse,
+    SelectedVariant,
+    VariantSource,
+)
 from .utils import (
     EXPOSURE_EVENT,
     REQUEST_HEADERS,
@@ -153,7 +159,7 @@ class RemoteFeatureFlagsProvider:
                 )
         except Exception:
             logger.exception("Failed to get remote variant for flag '%s'", flag_key)
-            return fallback_value
+            return fallback_value.as_fallback(FallbackReason.BACKEND_ERROR)
         else:
             return selected_variant
 
@@ -267,7 +273,7 @@ class RemoteFeatureFlagsProvider:
 
         except Exception:
             logger.exception("Failed to get remote variant for flag '%s'", flag_key)
-            return fallback_value
+            return fallback_value.as_fallback(FallbackReason.BACKEND_ERROR)
         else:
             return selected_variant
 
@@ -362,13 +368,17 @@ class RemoteFeatureFlagsProvider:
         fallback_value: SelectedVariant,
     ) -> tuple[SelectedVariant, bool]:
         if flag_key in flags:
-            return flags[flag_key], False
+            return flags[flag_key].with_source(VariantSource.REMOTE), False
         logger.debug(
             "Flag '%s' not found in remote response. Returning fallback, '%s'",
             flag_key,
             fallback_value,
         )
-        return fallback_value, True
+        # The /flags endpoint only returns variants the user is enrolled in,
+        # so a missing key could mean the flag doesn't exist OR the user
+        # isn't in any rollout. The remote SDK can't tell them apart without
+        # server-side help — surface as FLAG_NOT_FOUND for now.
+        return fallback_value.as_fallback(FallbackReason.FLAG_NOT_FOUND), True
 
     def shutdown(self):
         self._sync_client.close()

--- a/mixpanel/flags/remote_feature_flags.py
+++ b/mixpanel/flags/remote_feature_flags.py
@@ -157,9 +157,15 @@ class RemoteFeatureFlagsProvider:
                         distinct_id, EXPOSURE_EVENT, properties
                     )
                 )
-        except Exception:
+        except Exception as exc:
             logger.exception("Failed to get remote variant for flag '%s'", flag_key)
-            return fallback_value.as_fallback(FallbackReason.BACKEND_ERROR)
+            # SDK-83: attach the exception message so the OpenFeature wrapper
+            # can forward it as error_message. Without this the caller sees
+            # a bare GENERAL error and has to dig through logs to find out
+            # the backend rejected the request.
+            return fallback_value.as_fallback(
+                FallbackReason.backend_error(self._describe_backend_error(exc))
+            )
         else:
             return selected_variant
 
@@ -271,9 +277,13 @@ class RemoteFeatureFlagsProvider:
                 )
                 self._tracker(distinct_id, EXPOSURE_EVENT, properties)
 
-        except Exception:
+        except Exception as exc:
             logger.exception("Failed to get remote variant for flag '%s'", flag_key)
-            return fallback_value.as_fallback(FallbackReason.BACKEND_ERROR)
+            # SDK-83: attach the exception message so the OpenFeature wrapper
+            # can forward it as error_message.
+            return fallback_value.as_fallback(
+                FallbackReason.backend_error(self._describe_backend_error(exc))
+            )
         else:
             return selected_variant
 
@@ -361,6 +371,20 @@ class RemoteFeatureFlagsProvider:
         flags_response = RemoteFlagsResponse.model_validate(response.json())
         return flags_response.flags
 
+    @staticmethod
+    def _describe_backend_error(exc: Exception) -> str:
+        """Best-effort backend message for FallbackReason.backend_error.
+
+        For HTTP errors the response body usually contains the actionable
+        detail (e.g. "distinct_id must be provided in evalContext as a
+        string") — httpx's default str(exc) only carries the status line,
+        so reach into exc.response.text when available.
+        """
+        if isinstance(exc, httpx.HTTPStatusError):
+            body = exc.response.text.strip() if exc.response is not None else ""
+            return f"HTTP {exc.response.status_code}: {body}" if body else str(exc)
+        return str(exc)
+
     def _lookup_flag_in_response(
         self,
         flag_key: str,
@@ -378,7 +402,7 @@ class RemoteFeatureFlagsProvider:
         # so a missing key could mean the flag doesn't exist OR the user
         # isn't in any rollout. The remote SDK can't tell them apart without
         # server-side help — surface as FLAG_NOT_FOUND for now.
-        return fallback_value.as_fallback(FallbackReason.FLAG_NOT_FOUND), True
+        return fallback_value.as_fallback(FallbackReason.flag_not_found()), True
 
     def shutdown(self):
         self._sync_client.close()

--- a/mixpanel/flags/remote_feature_flags.py
+++ b/mixpanel/flags/remote_feature_flags.py
@@ -383,10 +383,18 @@ class RemoteFeatureFlagsProvider:
         detail (e.g. "distinct_id must be provided in evalContext as a
         string") — httpx's default str(exc) only carries the status line,
         so reach into exc.response.text when available.
+
+        Never fall back to ``str(exc)`` for HTTPStatusError: httpx's default
+        formatting includes the full request URL, which carries the project
+        token and distinct_id in the query string. Since this message is
+        forwarded verbatim into ``FlagResolutionDetails.error_message`` by
+        the OpenFeature wrapper, leaking those into user-visible output
+        would be a real regression (SDK-83 security review).
         """
         if isinstance(exc, httpx.HTTPStatusError):
             body = exc.response.text.strip() if exc.response is not None else ""
-            return f"HTTP {exc.response.status_code}: {body}" if body else str(exc)
+            status = exc.response.status_code if exc.response is not None else "?"
+            return f"HTTP {status}: {body}" if body else f"HTTP {status}"
         return str(exc)
 
     def _lookup_flag_in_response(

--- a/mixpanel/flags/remote_feature_flags.py
+++ b/mixpanel/flags/remote_feature_flags.py
@@ -100,6 +100,8 @@ class RemoteFeatureFlagsProvider:
         except Exception:
             logger.exception("Failed to get remote variants")
 
+        if flags is not None:
+            flags = {k: v.with_source(VariantSource.REMOTE) for k, v in flags.items()}
         return flags
 
     async def aget_variant_value(
@@ -222,6 +224,8 @@ class RemoteFeatureFlagsProvider:
         except Exception:
             logger.exception("Failed to get remote variants")
 
+        if flags is not None:
+            flags = {k: v.with_source(VariantSource.REMOTE) for k, v in flags.items()}
         return flags
 
     def get_variant_value(

--- a/mixpanel/flags/test_local_feature_flags.py
+++ b/mixpanel/flags/test_local_feature_flags.py
@@ -16,7 +16,6 @@ from .local_feature_flags import LocalFeatureFlagsProvider
 from .types import (
     ExperimentationFlag,
     ExperimentationFlags,
-    FallbackReason,
     FlagTestUsers,
     LocalFlagsConfig,
     Rollout,
@@ -741,7 +740,8 @@ class TestLocalFeatureFlagsProviderAsync:
         fallback = SelectedVariant(variant_value="fb")
         result = self._flags.get_variant("missing", fallback, USER_CONTEXT)
         assert result.variant_source == VariantSource.FALLBACK
-        assert result.fallback_reason == FallbackReason.FLAG_NOT_FOUND
+        assert result.fallback_reason.kind == "FLAG_NOT_FOUND"
+        assert result.fallback_reason.message is None
         assert result.variant_value == "fb"
 
     @respx.mock
@@ -751,7 +751,8 @@ class TestLocalFeatureFlagsProviderAsync:
         fallback = SelectedVariant(variant_value="fb")
         result = self._flags.get_variant(TEST_FLAG_KEY, fallback, {})
         assert result.variant_source == VariantSource.FALLBACK
-        assert result.fallback_reason == FallbackReason.MISSING_CONTEXT_KEY
+        assert result.fallback_reason.kind == "MISSING_CONTEXT_KEY"
+        assert result.fallback_reason.message == "distinct_id"
 
     @respx.mock
     async def test_get_variant_tags_no_rollout_match(self):
@@ -760,7 +761,7 @@ class TestLocalFeatureFlagsProviderAsync:
         fallback = SelectedVariant(variant_value="fb")
         result = self._flags.get_variant(TEST_FLAG_KEY, fallback, USER_CONTEXT)
         assert result.variant_source == VariantSource.FALLBACK
-        assert result.fallback_reason == FallbackReason.NO_ROLLOUT_MATCH
+        assert result.fallback_reason.kind == "NO_ROLLOUT_MATCH"
 
     @respx.mock
     async def test_get_variant_value_uses_most_recent_polled_flag(self):

--- a/mixpanel/flags/test_local_feature_flags.py
+++ b/mixpanel/flags/test_local_feature_flags.py
@@ -16,6 +16,7 @@ from .local_feature_flags import LocalFeatureFlagsProvider
 from .types import (
     ExperimentationFlag,
     ExperimentationFlags,
+    FallbackReason,
     FlagTestUsers,
     LocalFlagsConfig,
     Rollout,
@@ -23,6 +24,7 @@ from .types import (
     SelectedVariant,
     Variant,
     VariantOverride,
+    VariantSource,
 )
 
 TEST_FLAG_KEY = "test_flag"
@@ -722,6 +724,43 @@ class TestLocalFeatureFlagsProviderAsync:
         await self.setup_flags([flag])
         result = self._flags.is_enabled(TEST_FLAG_KEY, USER_CONTEXT)
         assert result is True
+
+    @respx.mock
+    async def test_get_variant_tags_match_as_local(self):
+        flag = create_test_flag(rollout_percentage=100.0)
+        await self.setup_flags([flag])
+        fallback = SelectedVariant(variant_value="fb")
+        result = self._flags.get_variant(TEST_FLAG_KEY, fallback, USER_CONTEXT)
+        assert result.variant_source == VariantSource.LOCAL
+        assert result.fallback_reason is None
+        assert result.variant_key is not None
+
+    @respx.mock
+    async def test_get_variant_tags_missing_flag(self):
+        await self.setup_flags([])
+        fallback = SelectedVariant(variant_value="fb")
+        result = self._flags.get_variant("missing", fallback, USER_CONTEXT)
+        assert result.variant_source == VariantSource.FALLBACK
+        assert result.fallback_reason == FallbackReason.FLAG_NOT_FOUND
+        assert result.variant_value == "fb"
+
+    @respx.mock
+    async def test_get_variant_tags_missing_context(self):
+        flag = create_test_flag(context="distinct_id")
+        await self.setup_flags([flag])
+        fallback = SelectedVariant(variant_value="fb")
+        result = self._flags.get_variant(TEST_FLAG_KEY, fallback, {})
+        assert result.variant_source == VariantSource.FALLBACK
+        assert result.fallback_reason == FallbackReason.MISSING_CONTEXT_KEY
+
+    @respx.mock
+    async def test_get_variant_tags_no_rollout_match(self):
+        flag = create_test_flag(rollout_percentage=0.0)
+        await self.setup_flags([flag])
+        fallback = SelectedVariant(variant_value="fb")
+        result = self._flags.get_variant(TEST_FLAG_KEY, fallback, USER_CONTEXT)
+        assert result.variant_source == VariantSource.FALLBACK
+        assert result.fallback_reason == FallbackReason.NO_ROLLOUT_MATCH
 
     @respx.mock
     async def test_get_variant_value_uses_most_recent_polled_flag(self):

--- a/mixpanel/flags/test_remote_feature_flags.py
+++ b/mixpanel/flags/test_remote_feature_flags.py
@@ -10,7 +10,12 @@ import respx
 from mixpanel.credentials import ServiceAccountCredentials
 
 from .remote_feature_flags import RemoteFeatureFlagsProvider
-from .types import RemoteFlagsConfig, RemoteFlagsResponse, SelectedVariant
+from .types import (
+    RemoteFlagsConfig,
+    RemoteFlagsResponse,
+    SelectedVariant,
+    VariantSource,
+)
 
 ENDPOINT = "https://api.mixpanel.com/flags"
 
@@ -264,6 +269,26 @@ class TestRemoteFeatureFlagsProviderSync:
             "test_flag", "control", {"distinct_id": "user123"}
         )
         assert result == "control"
+
+    @respx.mock
+    def test_get_variant_tags_fallback_with_backend_message_on_http_error(self):
+        """SDK-83: the backend's response message must propagate through
+        FallbackReason.message so the OpenFeature wrapper can forward it
+        as error_message instead of swallowing it into a bare GENERAL."""
+        respx.get(ENDPOINT).mock(
+            return_value=httpx.Response(
+                400, text="distinct_id must be provided in evalContext as a string"
+            )
+        )
+
+        fallback = SelectedVariant(variant_value="control")
+        result = self._flags.get_variant(
+            "test_flag", fallback, {"distinct_id": "user123"}, reportExposure=False
+        )
+
+        assert result.variant_source == VariantSource.FALLBACK
+        assert result.fallback_reason.kind == "BACKEND_ERROR"
+        assert "distinct_id must be provided" in result.fallback_reason.message
 
     @respx.mock
     def test_get_variant_value_is_fallback_if_bad_response_format(self):

--- a/mixpanel/flags/test_remote_feature_flags.py
+++ b/mixpanel/flags/test_remote_feature_flags.py
@@ -159,7 +159,11 @@ class TestRemoteFeatureFlagsProviderAsync:
 
         result = await self._flags.aget_all_variants({"distinct_id": "user123"})
 
-        assert result == variants
+        assert set(result.keys()) == {"flag1", "flag2"}
+        assert result["flag1"].variant_value == "value1"
+        assert result["flag2"].variant_value == "value2"
+        # Every returned variant must be tagged with variant_source=REMOTE.
+        assert all(v.variant_source == VariantSource.REMOTE for v in result.values())
 
     @respx.mock
     async def test_aget_all_variants_returns_none_on_network_error(self):
@@ -390,7 +394,10 @@ class TestRemoteFeatureFlagsProviderSync:
 
         result = self._flags.get_all_variants({"distinct_id": "user123"})
 
-        assert result == variants
+        assert set(result.keys()) == {"flag1", "flag2"}
+        assert result["flag1"].variant_value == "value1"
+        assert result["flag2"].variant_value == "value2"
+        assert all(v.variant_source == VariantSource.REMOTE for v in result.values())
 
     @respx.mock
     def test_get_all_variants_returns_none_on_network_error(self):

--- a/mixpanel/flags/test_remote_feature_flags.py
+++ b/mixpanel/flags/test_remote_feature_flags.py
@@ -295,6 +295,27 @@ class TestRemoteFeatureFlagsProviderSync:
         assert "distinct_id must be provided" in result.fallback_reason.message
 
     @respx.mock
+    def test_backend_error_message_never_leaks_token_or_distinct_id(self):
+        """Empty-body HTTP error must NOT expose the request URL — httpx's
+        default str(exc) formatting would include the query string, which
+        carries the project token and JSON-encoded context (SDK-83 security
+        review). Only the status code should surface downstream."""
+        respx.get(ENDPOINT).mock(return_value=httpx.Response(500, text=""))
+
+        fallback = SelectedVariant(variant_value="control")
+        result = self._flags.get_variant(
+            "test_flag", fallback, {"distinct_id": "user123"}, reportExposure=False
+        )
+
+        assert result.variant_source == VariantSource.FALLBACK
+        assert result.fallback_reason.kind == "BACKEND_ERROR"
+        message = result.fallback_reason.message
+        assert message == "HTTP 500"
+        assert "test-token" not in message
+        assert "distinct_id" not in message
+        assert "user123" not in message
+
+    @respx.mock
     def test_get_variant_value_is_fallback_if_bad_response_format(self):
         respx.get(ENDPOINT).mock(return_value=httpx.Response(200, text="invalid json"))
 

--- a/mixpanel/flags/types.py
+++ b/mixpanel/flags/types.py
@@ -109,7 +109,11 @@ class FallbackReason(BaseModel):
         return _NO_ROLLOUT_MATCH
 
     @classmethod
-    def missing_context_key(cls, key: Optional[str] = None) -> "FallbackReason":
+    def missing_context_key(cls, key: str) -> "FallbackReason":
+        # The whole point of MISSING_CONTEXT_KEY is telling the caller *which*
+        # attribute is absent; a nullable default would leak `message=None`
+        # into the OpenFeature wrapper's error_message and defeat the SDK-79
+        # richer-error-propagation goal.
         return cls(kind="MISSING_CONTEXT_KEY", message=key)
 
     @classmethod

--- a/mixpanel/flags/types.py
+++ b/mixpanel/flags/types.py
@@ -64,9 +64,11 @@ class ExperimentationFlag(BaseModel):
 
 
 class VariantSource:
-    """Where a SelectedVariant came from. Set by the providers on every
-    returned variant — coarse-grained (local / remote / fallback). For the
-    specific reason behind a fallback, see FallbackReason.
+    """Where a SelectedVariant came from.
+
+    Set by the providers on every returned variant — coarse-grained
+    (local / remote / fallback). For the specific reason behind a fallback,
+    see FallbackReason.
     """
 
     LOCAL = "local"
@@ -75,11 +77,12 @@ class VariantSource:
 
 
 class FallbackReason:
-    """Why the SDK returned the developer fallback. Only meaningful when
-    SelectedVariant.variant_source == VariantSource.FALLBACK. Matches the
-    constant set used by mixpanel-php so the OpenFeature wrapper can map to
-    the spec-correct error code instead of collapsing every fallback to
-    FLAG_NOT_FOUND.
+    """Why the SDK returned the developer fallback.
+
+    Only meaningful when SelectedVariant.variant_source == VariantSource.FALLBACK.
+    Matches the constant set used by mixpanel-php so the OpenFeature wrapper
+    can map to the spec-correct error code instead of collapsing every
+    fallback to FLAG_NOT_FOUND.
     """
 
     FLAG_NOT_FOUND = "FLAG_NOT_FOUND"
@@ -102,6 +105,7 @@ class SelectedVariant(BaseModel):
 
     def with_source(self, source: str) -> "SelectedVariant":
         """Return a copy of this variant tagged with the given source.
+
         Clears fallback_reason — use as_fallback() if returning a fallback.
         """
         return self.model_copy(

--- a/mixpanel/flags/types.py
+++ b/mixpanel/flags/types.py
@@ -86,10 +86,6 @@ class FallbackReason(BaseModel):
     MISSING_CONTEXT_KEY with the missing attribute name); None otherwise.
     The OpenFeature wrapper dispatches on kind and forwards message into
     FlagResolutionDetails.error_message.
-
-    Note: the wrapper handles PROVIDER_NOT_READY by short-circuiting before
-    invoking the provider (see MixpanelProvider._are_flags_ready), so there
-    is no NOT_READY kind here — no producer would ever construct it.
     """
 
     model_config = ConfigDict(frozen=True)

--- a/mixpanel/flags/types.py
+++ b/mixpanel/flags/types.py
@@ -63,6 +63,32 @@ class ExperimentationFlag(BaseModel):
     hash_salt: Optional[str] = None
 
 
+class VariantSource:
+    """Where a SelectedVariant came from. Set by the providers on every
+    returned variant — coarse-grained (local / remote / fallback). For the
+    specific reason behind a fallback, see FallbackReason.
+    """
+
+    LOCAL = "local"
+    REMOTE = "remote"
+    FALLBACK = "fallback"
+
+
+class FallbackReason:
+    """Why the SDK returned the developer fallback. Only meaningful when
+    SelectedVariant.variant_source == VariantSource.FALLBACK. Matches the
+    constant set used by mixpanel-php so the OpenFeature wrapper can map to
+    the spec-correct error code instead of collapsing every fallback to
+    FLAG_NOT_FOUND.
+    """
+
+    FLAG_NOT_FOUND = "FLAG_NOT_FOUND"
+    MISSING_CONTEXT_KEY = "MISSING_CONTEXT_KEY"
+    NO_ROLLOUT_MATCH = "NO_ROLLOUT_MATCH"
+    BACKEND_ERROR = "BACKEND_ERROR"
+    NOT_READY = "NOT_READY"
+
+
 class SelectedVariant(BaseModel):
     # variant_key can be None if being used as a fallback
     variant_key: Optional[str] = None
@@ -70,6 +96,26 @@ class SelectedVariant(BaseModel):
     experiment_id: Optional[str] = None
     is_experiment_active: Optional[bool] = None
     is_qa_tester: Optional[bool] = None
+    variant_source: Optional[str] = None
+    # None on success; one of FallbackReason.* when variant_source is FALLBACK
+    fallback_reason: Optional[str] = None
+
+    def with_source(self, source: str) -> "SelectedVariant":
+        """Return a copy of this variant tagged with the given source.
+        Clears fallback_reason — use as_fallback() if returning a fallback.
+        """
+        return self.model_copy(
+            update={"variant_source": source, "fallback_reason": None}
+        )
+
+    def as_fallback(self, reason: str) -> "SelectedVariant":
+        """Return a copy of this variant tagged as a fallback with the given reason."""
+        return self.model_copy(
+            update={
+                "variant_source": VariantSource.FALLBACK,
+                "fallback_reason": reason,
+            }
+        )
 
 
 class ExperimentationFlags(BaseModel):

--- a/mixpanel/flags/types.py
+++ b/mixpanel/flags/types.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any, Literal, Optional
 
 from pydantic import BaseModel, ConfigDict
 
@@ -76,20 +76,55 @@ class VariantSource:
     FALLBACK = "fallback"
 
 
-class FallbackReason:
+class FallbackReason(BaseModel):
     """Why the SDK returned the developer fallback.
 
     Only meaningful when SelectedVariant.variant_source == VariantSource.FALLBACK.
-    Matches the constant set used by mixpanel-php so the OpenFeature wrapper
-    can map to the spec-correct error code instead of collapsing every
-    fallback to FLAG_NOT_FOUND.
+
+    `kind` is the discriminator (PHP-aligned). `message` is set on reasons
+    that carry useful detail (BACKEND_ERROR with the backend's response body,
+    MISSING_CONTEXT_KEY with the missing attribute name); None otherwise.
+    The OpenFeature wrapper dispatches on kind and forwards message into
+    FlagResolutionDetails.error_message.
     """
 
-    FLAG_NOT_FOUND = "FLAG_NOT_FOUND"
-    MISSING_CONTEXT_KEY = "MISSING_CONTEXT_KEY"
-    NO_ROLLOUT_MATCH = "NO_ROLLOUT_MATCH"
-    BACKEND_ERROR = "BACKEND_ERROR"
-    NOT_READY = "NOT_READY"
+    model_config = ConfigDict(frozen=True)
+
+    kind: Literal[
+        "FLAG_NOT_FOUND",
+        "MISSING_CONTEXT_KEY",
+        "NO_ROLLOUT_MATCH",
+        "BACKEND_ERROR",
+        "NOT_READY",
+    ]
+    message: Optional[str] = None
+
+    # Factory methods. Reasons without meaningful detail return a frozen
+    # singleton; reasons with detail allocate per call.
+    @classmethod
+    def flag_not_found(cls) -> "FallbackReason":
+        return _FLAG_NOT_FOUND
+
+    @classmethod
+    def no_rollout_match(cls) -> "FallbackReason":
+        return _NO_ROLLOUT_MATCH
+
+    @classmethod
+    def not_ready(cls) -> "FallbackReason":
+        return _NOT_READY
+
+    @classmethod
+    def missing_context_key(cls, key: Optional[str] = None) -> "FallbackReason":
+        return cls(kind="MISSING_CONTEXT_KEY", message=key)
+
+    @classmethod
+    def backend_error(cls, message: str) -> "FallbackReason":
+        return cls(kind="BACKEND_ERROR", message=message)
+
+
+_FLAG_NOT_FOUND = FallbackReason(kind="FLAG_NOT_FOUND")
+_NO_ROLLOUT_MATCH = FallbackReason(kind="NO_ROLLOUT_MATCH")
+_NOT_READY = FallbackReason(kind="NOT_READY")
 
 
 class SelectedVariant(BaseModel):
@@ -100,8 +135,8 @@ class SelectedVariant(BaseModel):
     is_experiment_active: Optional[bool] = None
     is_qa_tester: Optional[bool] = None
     variant_source: Optional[str] = None
-    # None on success; one of FallbackReason.* when variant_source is FALLBACK
-    fallback_reason: Optional[str] = None
+    # None on success; set when variant_source == FALLBACK
+    fallback_reason: Optional[FallbackReason] = None
 
     def with_source(self, source: str) -> "SelectedVariant":
         """Return a copy of this variant tagged with the given source.
@@ -112,7 +147,7 @@ class SelectedVariant(BaseModel):
             update={"variant_source": source, "fallback_reason": None}
         )
 
-    def as_fallback(self, reason: str) -> "SelectedVariant":
+    def as_fallback(self, reason: FallbackReason) -> "SelectedVariant":
         """Return a copy of this variant tagged as a fallback with the given reason."""
         return self.model_copy(
             update={

--- a/mixpanel/flags/types.py
+++ b/mixpanel/flags/types.py
@@ -86,6 +86,10 @@ class FallbackReason(BaseModel):
     MISSING_CONTEXT_KEY with the missing attribute name); None otherwise.
     The OpenFeature wrapper dispatches on kind and forwards message into
     FlagResolutionDetails.error_message.
+
+    Note: the wrapper handles PROVIDER_NOT_READY by short-circuiting before
+    invoking the provider (see MixpanelProvider._are_flags_ready), so there
+    is no NOT_READY kind here — no producer would ever construct it.
     """
 
     model_config = ConfigDict(frozen=True)
@@ -95,7 +99,6 @@ class FallbackReason(BaseModel):
         "MISSING_CONTEXT_KEY",
         "NO_ROLLOUT_MATCH",
         "BACKEND_ERROR",
-        "NOT_READY",
     ]
     message: Optional[str] = None
 
@@ -110,10 +113,6 @@ class FallbackReason(BaseModel):
         return _NO_ROLLOUT_MATCH
 
     @classmethod
-    def not_ready(cls) -> "FallbackReason":
-        return _NOT_READY
-
-    @classmethod
     def missing_context_key(cls, key: Optional[str] = None) -> "FallbackReason":
         return cls(kind="MISSING_CONTEXT_KEY", message=key)
 
@@ -124,7 +123,6 @@ class FallbackReason(BaseModel):
 
 _FLAG_NOT_FOUND = FallbackReason(kind="FLAG_NOT_FOUND")
 _NO_ROLLOUT_MATCH = FallbackReason(kind="NO_ROLLOUT_MATCH")
-_NOT_READY = FallbackReason(kind="NOT_READY")
 
 
 class SelectedVariant(BaseModel):

--- a/openfeature-provider/src/mixpanel_openfeature/provider.py
+++ b/openfeature-provider/src/mixpanel_openfeature/provider.py
@@ -157,10 +157,11 @@ class MixpanelProvider(AbstractProvider):
         user_context = self._build_user_context(evaluation_context)
         try:
             result = self._flags_provider.get_variant(flag_key, fallback, user_context)
-        except Exception:
+        except Exception as exc:
             return FlagResolutionDetails(
                 value=default_value,
                 error_code=ErrorCode.GENERAL,
+                error_message=str(exc),
                 reason=Reason.ERROR,
             )
 
@@ -219,34 +220,35 @@ class MixpanelProvider(AbstractProvider):
 
     @staticmethod
     def _fallback_details(
-        fallback_reason: str | None, default_value: typing.Any
+        fallback_reason: FallbackReason | None, default_value: typing.Any
     ) -> FlagResolutionDetails | None:
         """Map a fallback reason to its OpenFeature response, or None if not a fallback.
 
         variant_source distinguishes local / remote / fallback. When fallback,
-        fallback_reason carries the specific reason (PHP-aligned constants)
-        so we map each to the spec-correct OpenFeature response instead of
-        collapsing every fallback to FLAG_NOT_FOUND.
+        fallback_reason carries the discriminating kind (PHP-aligned) and an
+        optional message (BACKEND_ERROR's response body, MISSING_CONTEXT_KEY's
+        missing attribute) so we map each to the spec-correct OpenFeature
+        response and forward the message as error_message.
         """
         if fallback_reason is None:
             return None
         # Flag exists, user just didn't match any rollout — per the
         # OpenFeature spec this is `reason: DEFAULT` with no error.
-        if fallback_reason == FallbackReason.NO_ROLLOUT_MATCH:
+        if fallback_reason.kind == "NO_ROLLOUT_MATCH":
             return FlagResolutionDetails(value=default_value, reason=Reason.DEFAULT)
         error_mapping = {
-            FallbackReason.FLAG_NOT_FOUND: (ErrorCode.FLAG_NOT_FOUND, Reason.DEFAULT),
-            FallbackReason.MISSING_CONTEXT_KEY: (
-                ErrorCode.TARGETING_KEY_MISSING,
-                Reason.ERROR,
-            ),
-            FallbackReason.BACKEND_ERROR: (ErrorCode.GENERAL, Reason.ERROR),
-            FallbackReason.NOT_READY: (ErrorCode.PROVIDER_NOT_READY, Reason.ERROR),
+            "FLAG_NOT_FOUND": (ErrorCode.FLAG_NOT_FOUND, Reason.DEFAULT),
+            "MISSING_CONTEXT_KEY": (ErrorCode.TARGETING_KEY_MISSING, Reason.ERROR),
+            "BACKEND_ERROR": (ErrorCode.GENERAL, Reason.ERROR),
+            "NOT_READY": (ErrorCode.PROVIDER_NOT_READY, Reason.ERROR),
         }
-        if fallback_reason in error_mapping:
-            error_code, reason = error_mapping[fallback_reason]
+        if fallback_reason.kind in error_mapping:
+            error_code, reason = error_mapping[fallback_reason.kind]
             return FlagResolutionDetails(
-                value=default_value, error_code=error_code, reason=reason
+                value=default_value,
+                error_code=error_code,
+                error_message=fallback_reason.message,
+                reason=reason,
             )
         return None
 

--- a/openfeature-provider/src/mixpanel_openfeature/provider.py
+++ b/openfeature-provider/src/mixpanel_openfeature/provider.py
@@ -236,11 +236,13 @@ class MixpanelProvider(AbstractProvider):
         # OpenFeature spec this is `reason: DEFAULT` with no error.
         if fallback_reason.kind == "NO_ROLLOUT_MATCH":
             return FlagResolutionDetails(value=default_value, reason=Reason.DEFAULT)
+        # PROVIDER_NOT_READY is handled before invoking the provider
+        # (see _are_flags_ready short-circuit at the top of resolve), so
+        # there's no NOT_READY kind to dispatch on here.
         error_mapping = {
             "FLAG_NOT_FOUND": (ErrorCode.FLAG_NOT_FOUND, Reason.DEFAULT),
             "MISSING_CONTEXT_KEY": (ErrorCode.TARGETING_KEY_MISSING, Reason.ERROR),
             "BACKEND_ERROR": (ErrorCode.GENERAL, Reason.ERROR),
-            "NOT_READY": (ErrorCode.PROVIDER_NOT_READY, Reason.ERROR),
         }
         if fallback_reason.kind in error_mapping:
             error_code, reason = error_mapping[fallback_reason.kind]

--- a/openfeature-provider/src/mixpanel_openfeature/provider.py
+++ b/openfeature-provider/src/mixpanel_openfeature/provider.py
@@ -139,7 +139,7 @@ class MixpanelProvider(AbstractProvider):
                 user_context["targetingKey"] = evaluation_context.targeting_key
         return user_context
 
-    def _resolve(
+    def _resolve(  # noqa: C901 — type-coercion branches are intentional
         self,
         flag_key: str,
         default_value: typing.Any,
@@ -163,6 +163,16 @@ class MixpanelProvider(AbstractProvider):
                 error_code=ErrorCode.GENERAL,
                 error_message=str(exc),
                 reason=Reason.ERROR,
+            )
+
+        # Defensive: a custom flags provider written against the pre-SDK-79
+        # contract may return the fallback object unchanged (no .as_fallback
+        # tag). Treat that as FLAG_NOT_FOUND rather than a successful match.
+        if self._is_untagged_fallback(result, fallback):
+            return FlagResolutionDetails(
+                value=default_value,
+                error_code=ErrorCode.FLAG_NOT_FOUND,
+                reason=Reason.DEFAULT,
             )
 
         fallback_details = self._fallback_details(
@@ -217,6 +227,12 @@ class MixpanelProvider(AbstractProvider):
         return FlagResolutionDetails(
             value=value, variant=variant_key, reason=Reason.TARGETING_MATCH
         )
+
+    @staticmethod
+    def _is_untagged_fallback(
+        result: SelectedVariant, fallback: SelectedVariant
+    ) -> bool:
+        return result is fallback and result.fallback_reason is None
 
     @staticmethod
     def _fallback_details(

--- a/openfeature-provider/src/mixpanel_openfeature/provider.py
+++ b/openfeature-provider/src/mixpanel_openfeature/provider.py
@@ -2,10 +2,8 @@ from __future__ import annotations
 
 import math
 import typing
-from collections.abc import Mapping, Sequence
-from typing import Optional, Union
+from typing import Union
 
-from openfeature.evaluation_context import EvaluationContext
 from openfeature.exception import ErrorCode
 from openfeature.flag_evaluation import FlagResolutionDetails, Reason
 from openfeature.provider import AbstractProvider, Metadata
@@ -18,6 +16,11 @@ from mixpanel.flags.types import (
     SelectedVariant,
 )
 
+if typing.TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+    from openfeature.evaluation_context import EvaluationContext
+
 FlagValueType = Union[bool, str, int, float, list, dict, None]
 
 
@@ -27,7 +30,7 @@ class MixpanelProvider(AbstractProvider):
     def __init__(
         self,
         flags_provider: typing.Any,
-        mixpanel_instance: Optional[Mixpanel] = None,
+        mixpanel_instance: Mixpanel | None = None,
     ) -> None:
         super().__init__()
         self._flags_provider = flags_provider
@@ -61,7 +64,7 @@ class MixpanelProvider(AbstractProvider):
         return cls(remote_flags, mixpanel_instance=mp)
 
     @property
-    def mixpanel(self) -> Optional[Mixpanel]:
+    def mixpanel(self) -> Mixpanel | None:
         """The Mixpanel instance used by this provider, if created via a class method."""
         return self._mixpanel
 
@@ -75,7 +78,7 @@ class MixpanelProvider(AbstractProvider):
         self,
         flag_key: str,
         default_value: bool,
-        evaluation_context: typing.Optional[EvaluationContext] = None,
+        evaluation_context: EvaluationContext | None = None,
     ) -> FlagResolutionDetails[bool]:
         return self._resolve(flag_key, default_value, bool, evaluation_context)
 
@@ -83,7 +86,7 @@ class MixpanelProvider(AbstractProvider):
         self,
         flag_key: str,
         default_value: str,
-        evaluation_context: typing.Optional[EvaluationContext] = None,
+        evaluation_context: EvaluationContext | None = None,
     ) -> FlagResolutionDetails[str]:
         return self._resolve(flag_key, default_value, str, evaluation_context)
 
@@ -91,7 +94,7 @@ class MixpanelProvider(AbstractProvider):
         self,
         flag_key: str,
         default_value: int,
-        evaluation_context: typing.Optional[EvaluationContext] = None,
+        evaluation_context: EvaluationContext | None = None,
     ) -> FlagResolutionDetails[int]:
         return self._resolve(flag_key, default_value, int, evaluation_context)
 
@@ -99,17 +102,17 @@ class MixpanelProvider(AbstractProvider):
         self,
         flag_key: str,
         default_value: float,
-        evaluation_context: typing.Optional[EvaluationContext] = None,
+        evaluation_context: EvaluationContext | None = None,
     ) -> FlagResolutionDetails[float]:
         return self._resolve(flag_key, default_value, float, evaluation_context)
 
     def resolve_object_details(
         self,
         flag_key: str,
-        default_value: Union[Sequence[FlagValueType], Mapping[str, FlagValueType]],
-        evaluation_context: typing.Optional[EvaluationContext] = None,
+        default_value: Sequence[FlagValueType] | Mapping[str, FlagValueType],
+        evaluation_context: EvaluationContext | None = None,
     ) -> FlagResolutionDetails[
-        Union[Sequence[FlagValueType], Mapping[str, FlagValueType]]
+        Sequence[FlagValueType] | Mapping[str, FlagValueType]
     ]:
         return self._resolve(flag_key, default_value, None, evaluation_context)
 
@@ -125,7 +128,7 @@ class MixpanelProvider(AbstractProvider):
 
     @staticmethod
     def _build_user_context(
-        evaluation_context: typing.Optional[EvaluationContext],
+        evaluation_context: EvaluationContext | None,
     ) -> dict:
         user_context: dict = {}
         if evaluation_context is not None:
@@ -140,8 +143,8 @@ class MixpanelProvider(AbstractProvider):
         self,
         flag_key: str,
         default_value: typing.Any,
-        expected_type: typing.Optional[type],
-        evaluation_context: typing.Optional[EvaluationContext] = None,
+        expected_type: type | None,
+        evaluation_context: EvaluationContext | None = None,
     ) -> FlagResolutionDetails:
         if not self._are_flags_ready():
             return FlagResolutionDetails(
@@ -161,41 +164,11 @@ class MixpanelProvider(AbstractProvider):
                 reason=Reason.ERROR,
             )
 
-        # variant_source distinguishes local / remote / fallback. When fallback,
-        # fallback_reason carries the specific reason (PHP-aligned constants)
-        # so we can map each to the spec-correct OpenFeature response instead
-        # of collapsing every fallback to FLAG_NOT_FOUND.
-        if result.fallback_reason == FallbackReason.FLAG_NOT_FOUND:
-            return FlagResolutionDetails(
-                value=default_value,
-                error_code=ErrorCode.FLAG_NOT_FOUND,
-                reason=Reason.DEFAULT,
-            )
-        if result.fallback_reason == FallbackReason.MISSING_CONTEXT_KEY:
-            return FlagResolutionDetails(
-                value=default_value,
-                error_code=ErrorCode.TARGETING_KEY_MISSING,
-                reason=Reason.ERROR,
-            )
-        if result.fallback_reason == FallbackReason.NO_ROLLOUT_MATCH:
-            # Flag exists, user just didn't match any rollout — per the
-            # OpenFeature spec this is `reason: DEFAULT` with no error.
-            return FlagResolutionDetails(
-                value=default_value,
-                reason=Reason.DEFAULT,
-            )
-        if result.fallback_reason == FallbackReason.BACKEND_ERROR:
-            return FlagResolutionDetails(
-                value=default_value,
-                error_code=ErrorCode.GENERAL,
-                reason=Reason.ERROR,
-            )
-        if result.fallback_reason == FallbackReason.NOT_READY:
-            return FlagResolutionDetails(
-                value=default_value,
-                error_code=ErrorCode.PROVIDER_NOT_READY,
-                reason=Reason.ERROR,
-            )
+        fallback_details = self._fallback_details(
+            result.fallback_reason, default_value
+        )
+        if fallback_details is not None:
+            return fallback_details
 
         value = result.variant_value
         variant_key = result.variant_key
@@ -243,6 +216,39 @@ class MixpanelProvider(AbstractProvider):
         return FlagResolutionDetails(
             value=value, variant=variant_key, reason=Reason.TARGETING_MATCH
         )
+
+    @staticmethod
+    def _fallback_details(
+        fallback_reason: str | None, default_value: typing.Any
+    ) -> FlagResolutionDetails | None:
+        """Map a fallback reason to its OpenFeature response, or None if not a fallback.
+
+        variant_source distinguishes local / remote / fallback. When fallback,
+        fallback_reason carries the specific reason (PHP-aligned constants)
+        so we map each to the spec-correct OpenFeature response instead of
+        collapsing every fallback to FLAG_NOT_FOUND.
+        """
+        if fallback_reason is None:
+            return None
+        # Flag exists, user just didn't match any rollout — per the
+        # OpenFeature spec this is `reason: DEFAULT` with no error.
+        if fallback_reason == FallbackReason.NO_ROLLOUT_MATCH:
+            return FlagResolutionDetails(value=default_value, reason=Reason.DEFAULT)
+        error_mapping = {
+            FallbackReason.FLAG_NOT_FOUND: (ErrorCode.FLAG_NOT_FOUND, Reason.DEFAULT),
+            FallbackReason.MISSING_CONTEXT_KEY: (
+                ErrorCode.TARGETING_KEY_MISSING,
+                Reason.ERROR,
+            ),
+            FallbackReason.BACKEND_ERROR: (ErrorCode.GENERAL, Reason.ERROR),
+            FallbackReason.NOT_READY: (ErrorCode.PROVIDER_NOT_READY, Reason.ERROR),
+        }
+        if fallback_reason in error_mapping:
+            error_code, reason = error_mapping[fallback_reason]
+            return FlagResolutionDetails(
+                value=default_value, error_code=error_code, reason=reason
+            )
+        return None
 
     def _are_flags_ready(self) -> bool:
         if hasattr(self._flags_provider, "are_flags_ready"):

--- a/openfeature-provider/src/mixpanel_openfeature/provider.py
+++ b/openfeature-provider/src/mixpanel_openfeature/provider.py
@@ -11,7 +11,12 @@ from openfeature.flag_evaluation import FlagResolutionDetails, Reason
 from openfeature.provider import AbstractProvider, Metadata
 
 from mixpanel import Mixpanel
-from mixpanel.flags.types import LocalFlagsConfig, RemoteFlagsConfig, SelectedVariant
+from mixpanel.flags.types import (
+    FallbackReason,
+    LocalFlagsConfig,
+    RemoteFlagsConfig,
+    SelectedVariant,
+)
 
 FlagValueType = Union[bool, str, int, float, list, dict, None]
 
@@ -156,11 +161,40 @@ class MixpanelProvider(AbstractProvider):
                 reason=Reason.ERROR,
             )
 
-        if result is fallback:
+        # variant_source distinguishes local / remote / fallback. When fallback,
+        # fallback_reason carries the specific reason (PHP-aligned constants)
+        # so we can map each to the spec-correct OpenFeature response instead
+        # of collapsing every fallback to FLAG_NOT_FOUND.
+        if result.fallback_reason == FallbackReason.FLAG_NOT_FOUND:
             return FlagResolutionDetails(
                 value=default_value,
                 error_code=ErrorCode.FLAG_NOT_FOUND,
                 reason=Reason.DEFAULT,
+            )
+        if result.fallback_reason == FallbackReason.MISSING_CONTEXT_KEY:
+            return FlagResolutionDetails(
+                value=default_value,
+                error_code=ErrorCode.TARGETING_KEY_MISSING,
+                reason=Reason.ERROR,
+            )
+        if result.fallback_reason == FallbackReason.NO_ROLLOUT_MATCH:
+            # Flag exists, user just didn't match any rollout — per the
+            # OpenFeature spec this is `reason: DEFAULT` with no error.
+            return FlagResolutionDetails(
+                value=default_value,
+                reason=Reason.DEFAULT,
+            )
+        if result.fallback_reason == FallbackReason.BACKEND_ERROR:
+            return FlagResolutionDetails(
+                value=default_value,
+                error_code=ErrorCode.GENERAL,
+                reason=Reason.ERROR,
+            )
+        if result.fallback_reason == FallbackReason.NOT_READY:
+            return FlagResolutionDetails(
+                value=default_value,
+                error_code=ErrorCode.PROVIDER_NOT_READY,
+                reason=Reason.ERROR,
             )
 
         value = result.variant_value

--- a/openfeature-provider/src/mixpanel_openfeature/provider.py
+++ b/openfeature-provider/src/mixpanel_openfeature/provider.py
@@ -236,9 +236,6 @@ class MixpanelProvider(AbstractProvider):
         # OpenFeature spec this is `reason: DEFAULT` with no error.
         if fallback_reason.kind == "NO_ROLLOUT_MATCH":
             return FlagResolutionDetails(value=default_value, reason=Reason.DEFAULT)
-        # PROVIDER_NOT_READY is handled before invoking the provider
-        # (see _are_flags_ready short-circuit at the top of resolve), so
-        # there's no NOT_READY kind to dispatch on here.
         error_mapping = {
             "FLAG_NOT_FOUND": (ErrorCode.FLAG_NOT_FOUND, Reason.DEFAULT),
             "MISSING_CONTEXT_KEY": (ErrorCode.TARGETING_KEY_MISSING, Reason.ERROR),

--- a/openfeature-provider/src/mixpanel_openfeature/provider.py
+++ b/openfeature-provider/src/mixpanel_openfeature/provider.py
@@ -265,7 +265,17 @@ class MixpanelProvider(AbstractProvider):
                 error_message=fallback_reason.message,
                 reason=reason,
             )
-        return None
+        # Exhaustive: every FallbackReason.Kind Literal is handled above. If a
+        # new kind is added to the enum without also being wired into the
+        # mapping (or NO_ROLLOUT_MATCH branch above), fall back to GENERAL
+        # rather than returning None — which _resolve would silently
+        # misinterpret as a successful targeting match.
+        return FlagResolutionDetails(
+            value=default_value,
+            error_code=ErrorCode.GENERAL,
+            error_message=f"Unrecognized fallback_reason.kind: {fallback_reason.kind}",
+            reason=Reason.ERROR,
+        )
 
     def _are_flags_ready(self) -> bool:
         if hasattr(self._flags_provider, "are_flags_ready"):

--- a/openfeature-provider/tests/test_provider.py
+++ b/openfeature-provider/tests/test_provider.py
@@ -30,7 +30,7 @@ def setup_flag(mock_flags, flag_key, value, variant_key="variant-key"):
             variant_source=VariantSource.LOCAL,
         )
         if key == flag_key
-        else fallback.as_fallback(FallbackReason.FLAG_NOT_FOUND)
+        else fallback.as_fallback(FallbackReason.flag_not_found())
     )
 
 
@@ -43,7 +43,7 @@ def setup_fallback(mock_flags, reason):
 
 def setup_flag_not_found(mock_flags, flag_key):
     """Configure mock for the genuinely-missing-flag path."""
-    setup_fallback(mock_flags, FallbackReason.FLAG_NOT_FOUND)
+    setup_fallback(mock_flags, FallbackReason.flag_not_found())
 
 
 # --- Metadata ---
@@ -322,7 +322,7 @@ def test_remote_provider_always_ready():
 
 
 def test_no_rollout_match_returns_default_reason_without_error(provider, mock_flags):
-    setup_fallback(mock_flags, FallbackReason.NO_ROLLOUT_MATCH)
+    setup_fallback(mock_flags, FallbackReason.no_rollout_match())
     result = provider.resolve_boolean_details("flag", True)
     assert result.value is True
     assert result.reason == Reason.DEFAULT
@@ -330,7 +330,7 @@ def test_no_rollout_match_returns_default_reason_without_error(provider, mock_fl
 
 
 def test_no_rollout_match_for_string(provider, mock_flags):
-    setup_fallback(mock_flags, FallbackReason.NO_ROLLOUT_MATCH)
+    setup_fallback(mock_flags, FallbackReason.no_rollout_match())
     result = provider.resolve_string_details("flag", "default")
     assert result.value == "default"
     assert result.reason == Reason.DEFAULT
@@ -341,37 +341,46 @@ def test_no_rollout_match_for_string(provider, mock_flags):
 
 
 def test_missing_context_key_returns_targeting_key_missing(provider, mock_flags):
-    setup_fallback(mock_flags, FallbackReason.MISSING_CONTEXT_KEY)
+    setup_fallback(mock_flags, FallbackReason.missing_context_key("distinct_id"))
     result = provider.resolve_boolean_details("flag", False)
     assert result.value is False
     assert result.error_code == ErrorCode.TARGETING_KEY_MISSING
     assert result.reason == Reason.ERROR
 
 
-def test_missing_context_key_for_string(provider, mock_flags):
-    setup_fallback(mock_flags, FallbackReason.MISSING_CONTEXT_KEY)
+def test_missing_context_key_forwards_missing_attribute_as_error_message(
+    provider, mock_flags
+):
+    setup_fallback(mock_flags, FallbackReason.missing_context_key("distinct_id"))
     result = provider.resolve_string_details("flag", "default")
     assert result.value == "default"
     assert result.error_code == ErrorCode.TARGETING_KEY_MISSING
+    assert result.error_message == "distinct_id"
     assert result.reason == Reason.ERROR
 
 
-# --- Backend error ---
+# --- Backend error (SDK-83: forwards the backend's response message) ---
 
 
-def test_backend_error_maps_to_general(provider, mock_flags):
-    setup_fallback(mock_flags, FallbackReason.BACKEND_ERROR)
+def test_backend_error_maps_to_general_and_forwards_message(provider, mock_flags):
+    setup_fallback(
+        mock_flags,
+        FallbackReason.backend_error(
+            "HTTP 400: distinct_id must be provided in evalContext as a string"
+        ),
+    )
     result = provider.resolve_string_details("flag", "default")
     assert result.value == "default"
     assert result.error_code == ErrorCode.GENERAL
     assert result.reason == Reason.ERROR
+    assert "distinct_id must be provided" in result.error_message
 
 
 # --- Not ready ---
 
 
 def test_not_ready_reason_maps_to_provider_not_ready(provider, mock_flags):
-    setup_fallback(mock_flags, FallbackReason.NOT_READY)
+    setup_fallback(mock_flags, FallbackReason.not_ready())
     result = provider.resolve_boolean_details("flag", True)
     assert result.value is True
     assert result.error_code == ErrorCode.PROVIDER_NOT_READY

--- a/openfeature-provider/tests/test_provider.py
+++ b/openfeature-provider/tests/test_provider.py
@@ -5,7 +5,7 @@ from openfeature.evaluation_context import EvaluationContext
 from openfeature.exception import ErrorCode
 from openfeature.flag_evaluation import Reason
 
-from mixpanel.flags.types import SelectedVariant
+from mixpanel.flags.types import FallbackReason, SelectedVariant, VariantSource
 from mixpanel_openfeature import MixpanelProvider
 
 
@@ -22,17 +22,28 @@ def provider(mock_flags):
 
 
 def setup_flag(mock_flags, flag_key, value, variant_key="variant-key"):
-    """Configure mock to return a SelectedVariant with the given value."""
+    """Configure mock to return a successfully-evaluated SelectedVariant."""
     mock_flags.get_variant.side_effect = lambda key, fallback, ctx: (
-        SelectedVariant(variant_key=variant_key, variant_value=value)
+        SelectedVariant(
+            variant_key=variant_key,
+            variant_value=value,
+            variant_source=VariantSource.LOCAL,
+        )
         if key == flag_key
-        else fallback
+        else fallback.as_fallback(FallbackReason.FLAG_NOT_FOUND)
     )
 
 
-def setup_flag_not_found(mock_flags, flag_key):
-    """Configure mock to return the fallback (identity check triggers FLAG_NOT_FOUND)."""
-    mock_flags.get_variant.side_effect = lambda key, fallback, ctx: fallback
+def setup_fallback(mock_flags, reason):
+    """Configure mock to always return the caller's fallback tagged with `reason`."""
+    mock_flags.get_variant.side_effect = (
+        lambda key, fallback, ctx: fallback.as_fallback(reason)
+    )
+
+
+def setup_flag_not_found(mock_flags, flag_key):  # noqa: ARG001 - flag_key kept for call-site clarity
+    """Configure mock for the genuinely-missing-flag path."""
+    setup_fallback(mock_flags, FallbackReason.FLAG_NOT_FOUND)
 
 
 # --- Metadata ---
@@ -298,13 +309,73 @@ def test_remote_provider_always_ready():
     remote_flags = MagicMock(spec=[])  # empty spec = no attributes
     remote_flags.get_variant = MagicMock(
         side_effect=lambda key, fallback, ctx: SelectedVariant(
-            variant_key="v1", variant_value=True
+            variant_key="v1", variant_value=True, variant_source=VariantSource.REMOTE
         )
     )
     provider = MixpanelProvider(remote_flags)
     result = provider.resolve_boolean_details("flag", False)
     assert result.value is True
     assert result.reason == Reason.TARGETING_MATCH
+
+
+# --- No rollout matched (flag exists, no rollout matched) ---
+
+
+def test_no_rollout_match_returns_default_reason_without_error(provider, mock_flags):
+    setup_fallback(mock_flags, FallbackReason.NO_ROLLOUT_MATCH)
+    result = provider.resolve_boolean_details("flag", True)
+    assert result.value is True
+    assert result.reason == Reason.DEFAULT
+    assert result.error_code is None
+
+
+def test_no_rollout_match_for_string(provider, mock_flags):
+    setup_fallback(mock_flags, FallbackReason.NO_ROLLOUT_MATCH)
+    result = provider.resolve_string_details("flag", "default")
+    assert result.value == "default"
+    assert result.reason == Reason.DEFAULT
+    assert result.error_code is None
+
+
+# --- Missing context key ---
+
+
+def test_missing_context_key_returns_targeting_key_missing(provider, mock_flags):
+    setup_fallback(mock_flags, FallbackReason.MISSING_CONTEXT_KEY)
+    result = provider.resolve_boolean_details("flag", False)
+    assert result.value is False
+    assert result.error_code == ErrorCode.TARGETING_KEY_MISSING
+    assert result.reason == Reason.ERROR
+
+
+def test_missing_context_key_for_string(provider, mock_flags):
+    setup_fallback(mock_flags, FallbackReason.MISSING_CONTEXT_KEY)
+    result = provider.resolve_string_details("flag", "default")
+    assert result.value == "default"
+    assert result.error_code == ErrorCode.TARGETING_KEY_MISSING
+    assert result.reason == Reason.ERROR
+
+
+# --- Backend error ---
+
+
+def test_backend_error_maps_to_general(provider, mock_flags):
+    setup_fallback(mock_flags, FallbackReason.BACKEND_ERROR)
+    result = provider.resolve_string_details("flag", "default")
+    assert result.value == "default"
+    assert result.error_code == ErrorCode.GENERAL
+    assert result.reason == Reason.ERROR
+
+
+# --- Not ready ---
+
+
+def test_not_ready_reason_maps_to_provider_not_ready(provider, mock_flags):
+    setup_fallback(mock_flags, FallbackReason.NOT_READY)
+    result = provider.resolve_boolean_details("flag", True)
+    assert result.value is True
+    assert result.error_code == ErrorCode.PROVIDER_NOT_READY
+    assert result.reason == Reason.ERROR
 
 
 # --- Lifecycle ---

--- a/openfeature-provider/tests/test_provider.py
+++ b/openfeature-provider/tests/test_provider.py
@@ -163,6 +163,20 @@ def test_flag_not_found_boolean(provider, mock_flags):
     assert result.reason == Reason.DEFAULT
 
 
+def test_bare_fallback_treated_as_flag_not_found(provider, mock_flags):
+    """A custom flags provider written against the pre-SDK-79 contract may
+    return the fallback object unchanged (no .as_fallback tag). Treat that
+    as FLAG_NOT_FOUND rather than a successful targeting match."""
+    # Return the fallback object as-is with no fallback_reason set.
+    mock_flags.get_variant.side_effect = (
+        lambda _key, fallback, _ctx, **_kwargs: fallback
+    )
+    result = provider.resolve_string_details("any-flag", "default")
+    assert result.value == "default"
+    assert result.error_code == ErrorCode.FLAG_NOT_FOUND
+    assert result.reason == Reason.DEFAULT
+
+
 def test_flag_not_found_string(provider, mock_flags):
     setup_flag_not_found(mock_flags, "missing-flag")
     result = provider.resolve_string_details("missing-flag", "fallback")

--- a/openfeature-provider/tests/test_provider.py
+++ b/openfeature-provider/tests/test_provider.py
@@ -376,15 +376,10 @@ def test_backend_error_maps_to_general_and_forwards_message(provider, mock_flags
     assert "distinct_id must be provided" in result.error_message
 
 
-# --- Not ready ---
-
-
-def test_not_ready_reason_maps_to_provider_not_ready(provider, mock_flags):
-    setup_fallback(mock_flags, FallbackReason.not_ready())
-    result = provider.resolve_boolean_details("flag", True)
-    assert result.value is True
-    assert result.error_code == ErrorCode.PROVIDER_NOT_READY
-    assert result.reason == Reason.ERROR
+# Not-ready handling is covered by the test_provider_not_ready_* tests above,
+# which exercise the wrapper's are_flags_ready short-circuit. The provider
+# never stamps a NOT_READY fallback reason, so there is no producer-side
+# dispatch to test here.
 
 
 # --- Lifecycle ---

--- a/openfeature-provider/tests/test_provider.py
+++ b/openfeature-provider/tests/test_provider.py
@@ -41,7 +41,7 @@ def setup_fallback(mock_flags, reason):
     )
 
 
-def setup_flag_not_found(mock_flags, flag_key):  # noqa: ARG001 - flag_key kept for call-site clarity
+def setup_flag_not_found(mock_flags, flag_key):
     """Configure mock for the genuinely-missing-flag path."""
     setup_fallback(mock_flags, FallbackReason.FLAG_NOT_FOUND)
 

--- a/openfeature-provider/tests/test_provider.py
+++ b/openfeature-provider/tests/test_provider.py
@@ -376,12 +376,6 @@ def test_backend_error_maps_to_general_and_forwards_message(provider, mock_flags
     assert "distinct_id must be provided" in result.error_message
 
 
-# Not-ready handling is covered by the test_provider_not_ready_* tests above,
-# which exercise the wrapper's are_flags_ready short-circuit. The provider
-# never stamps a NOT_READY fallback reason, so there is no producer-side
-# dispatch to test here.
-
-
 # --- Lifecycle ---
 
 


### PR DESCRIPTION
## Summary

Bundles two related fixes. Both touch the same `fallback_reason` plumbing so they merge as one PR.

### SDK-79 — distinguish fallback reasons (local eval)

Three local-evaluation outcomes — flag-not-found, no-rollout-match, and missing-context-key — previously all returned the bare developer fallback. The OpenFeature wrapper collapsed them to `FLAG_NOT_FOUND`, sending callers chasing the flag name when the real cause was usually a rule miss or absent context.

`SelectedVariant` now carries two source fields: `variant_source` (`local` / `remote` / `fallback`) and `fallback_reason` (set only when source is `fallback`). The wrapper dispatches on `fallback_reason` and maps each to the spec-correct OpenFeature response — most notably, `NO_ROLLOUT_MATCH` becomes `reason: DEFAULT` with no error code instead of `FLAG_NOT_FOUND`.

### SDK-83 — forward the backend's error message (remote eval)

When the remote `/flags` endpoint returned an error response (e.g. HTTP 400 with "distinct_id must be provided in evalContext as a string"), the catch block returned the fallback variant without attaching the cause. The wrapper saw a fallback and translated to `FLAG_NOT_FOUND` — indistinguishable from a genuinely missing flag. Go propagates these as `GENERAL` with the full backend message; the goal here is to match that.

To carry the message, `FallbackReason` is upgraded from a bare string constant to a small value object with `kind` (the PHP-aligned discriminator) and optional `message` (set on `BACKEND_ERROR` and `MISSING_CONTEXT_KEY`). The remote provider's catch branches tag the fallback with `FallbackReason.backend_error(message)`; the wrapper forwards `message` into OpenFeature's `error_message` / `errorMessage`.

## Fix pattern

### `FallbackReason` kinds (PHP-aligned)

| Kind | When it fires | Carries message? |
| --- | --- | --- |
| `FLAG_NOT_FOUND` | Flag key not in the ruleset / absent from `/flags` response | no |
| `MISSING_CONTEXT_KEY` | Required context attribute (distinct_id / targeting key) absent | the missing attribute name |
| `NO_ROLLOUT_MATCH` | Flag exists, user isn't in any rollout | no |
| `BACKEND_ERROR` | Remote `/flags` error response | the backend's response body (SDK-83) |

`PROVIDER_NOT_READY` is handled by the wrapper's `_are_flags_ready` short-circuit before invoking the underlying provider, so no producer ever stamps a `NOT_READY` kind.

### OpenFeature mapping

| Kind | OpenFeature response |
| --- | --- |
| `FLAG_NOT_FOUND` | `error_code: FLAG_NOT_FOUND`, `reason: DEFAULT` |
| `MISSING_CONTEXT_KEY` | `error_code: TARGETING_KEY_MISSING`, `reason: ERROR`, **`error_message: <attribute name>`** |
| `NO_ROLLOUT_MATCH` | `reason: DEFAULT`, no error |
| `BACKEND_ERROR` | `error_code: GENERAL`, `reason: ERROR`, **`error_message: <backend body>`** |

## Test plan

- [x] Full base SDK + OpenFeature wrapper test suites pass (145 tests)
- [x] New `BACKEND_ERROR` producer-side test verifies the backend response body propagates through to `fallback_reason.message`
- [x] Wrapper test verifies `error_message` / `errorMessage` forwards the backend message for `BACKEND_ERROR` and the missing-attribute name for `MISSING_CONTEXT_KEY`

🤖 Generated with [Claude Code](https://claude.com/claude-code)