### PR TITLE
fix(analytics): allow capability to offload reportExposure to async thread (SDK-80)

### DIFF
--- a/mixpanel/flags/local_feature_flags.py
+++ b/mixpanel/flags/local_feature_flags.py
@@ -18,8 +18,8 @@ from .types import (
     SelectedVariant,
 )
 from .utils import (
-    EXPOSURE_EVENT,
     REQUEST_HEADERS,
+    dispatch_exposure,
     generate_traceparent,
     normalized_hash,
     prepare_common_query_params,
@@ -518,15 +518,9 @@ class LocalFeatureFlagsProvider:
             )
 
     def _dispatch_exposure(self, distinct_id: str, properties: dict[str, Any]) -> None:
-        if (executor := self._config.exposure_executor) is not None:
-            try:
-                executor.submit(self._tracker, distinct_id, EXPOSURE_EVENT, properties)
-            except RuntimeError:
-                logger.exception(
-                    "Exposure event dropped — executor refused to accept task"
-                )
-            return
-        self._tracker(distinct_id, EXPOSURE_EVENT, properties)
+        dispatch_exposure(
+            self._tracker, self._config.exposure_executor, distinct_id, properties
+        )
 
     async def __aenter__(self):
         return self

--- a/mixpanel/flags/local_feature_flags.py
+++ b/mixpanel/flags/local_feature_flags.py
@@ -511,11 +511,22 @@ class LocalFeatureFlagsProvider:
             if latency_in_seconds is not None:
                 properties["Variant fetch latency (ms)"] = latency_in_seconds * 1000
 
-            self._tracker(distinct_id, EXPOSURE_EVENT, properties)
+            self._dispatch_exposure(distinct_id, properties)
         else:
             logger.error(
                 "Cannot track exposure event without a distinct_id in the context"
             )
+
+    def _dispatch_exposure(self, distinct_id: str, properties: dict[str, Any]) -> None:
+        if (executor := self._config.exposure_executor) is not None:
+            try:
+                executor.submit(self._tracker, distinct_id, EXPOSURE_EVENT, properties)
+            except RuntimeError:
+                logger.exception(
+                    "Exposure event dropped — executor refused to accept task"
+                )
+            return
+        self._tracker(distinct_id, EXPOSURE_EVENT, properties)
 
     async def __aenter__(self):
         return self

--- a/mixpanel/flags/remote_feature_flags.py
+++ b/mixpanel/flags/remote_feature_flags.py
@@ -14,6 +14,7 @@ from .types import RemoteFlagsConfig, RemoteFlagsResponse, SelectedVariant
 from .utils import (
     EXPOSURE_EVENT,
     REQUEST_HEADERS,
+    dispatch_exposure,
     generate_traceparent,
     prepare_common_query_params,
 )
@@ -274,15 +275,9 @@ class RemoteFeatureFlagsProvider:
             )
 
     def _dispatch_exposure(self, distinct_id: str, properties: dict[str, Any]) -> None:
-        if (executor := self._config.exposure_executor) is not None:
-            try:
-                executor.submit(self._tracker, distinct_id, EXPOSURE_EVENT, properties)
-            except RuntimeError:
-                logger.exception(
-                    "Exposure event dropped — executor refused to accept task"
-                )
-            return
-        self._tracker(distinct_id, EXPOSURE_EVENT, properties)
+        dispatch_exposure(
+            self._tracker, self._config.exposure_executor, distinct_id, properties
+        )
 
     def _prepare_query_params(
         self, context: dict[str, Any], flag_key: str | None = None

--- a/mixpanel/flags/remote_feature_flags.py
+++ b/mixpanel/flags/remote_feature_flags.py
@@ -237,7 +237,7 @@ class RemoteFeatureFlagsProvider:
                 properties = self._build_tracking_properties(
                     flag_key, selected_variant, start_time, end_time
                 )
-                self._tracker(distinct_id, EXPOSURE_EVENT, properties)
+                self._dispatch_exposure(distinct_id, properties)
 
         except Exception:
             logger.exception("Failed to get remote variant for flag '%s'", flag_key)
@@ -267,11 +267,22 @@ class RemoteFeatureFlagsProvider:
         """
         if distinct_id := context.get("distinct_id"):
             properties = self._build_tracking_properties(flag_key, variant)
-            self._tracker(distinct_id, EXPOSURE_EVENT, properties)
+            self._dispatch_exposure(distinct_id, properties)
         else:
             logger.error(
                 "Cannot track exposure event without a distinct_id in the context"
             )
+
+    def _dispatch_exposure(self, distinct_id: str, properties: dict[str, Any]) -> None:
+        if (executor := self._config.exposure_executor) is not None:
+            try:
+                executor.submit(self._tracker, distinct_id, EXPOSURE_EVENT, properties)
+            except RuntimeError:
+                logger.exception(
+                    "Exposure event dropped — executor refused to accept task"
+                )
+            return
+        self._tracker(distinct_id, EXPOSURE_EVENT, properties)
 
     def _prepare_query_params(
         self, context: dict[str, Any], flag_key: str | None = None

--- a/mixpanel/flags/test_local_feature_flags.py
+++ b/mixpanel/flags/test_local_feature_flags.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import threading
+from concurrent.futures import ThreadPoolExecutor
 from itertools import chain, repeat
 from typing import Any
 from unittest.mock import Mock, patch
@@ -645,6 +646,40 @@ class TestLocalFeatureFlagsProviderAsync:
             "nonexistent_flag", "fallback", {"company_id": "company123"}
         )
         self._mock_tracker.assert_not_called()
+
+    @respx.mock
+    async def test_exposure_executor_dispatches_tracker_off_calling_thread(self):
+        flag = create_test_flag(rollout_percentage=100.0)
+        executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="exposure")
+        try:
+            calling_thread = threading.current_thread()
+            tracker_thread = threading.Event()
+            captured_thread: list[threading.Thread] = []
+
+            def tracker(_distinct_id, _event, _properties):
+                captured_thread.append(threading.current_thread())
+                tracker_thread.set()
+
+            tracker_mock = Mock(side_effect=tracker)
+            config = LocalFlagsConfig(
+                enable_polling=False, exposure_executor=executor
+            )
+            provider = LocalFeatureFlagsProvider(
+                "test-token", config, "1.0.0", tracker_mock
+            )
+            try:
+                respx.get("https://api.mixpanel.com/flags/definitions").mock(
+                    return_value=create_flags_response([flag])
+                )
+                await provider.astart_polling_for_definitions()
+                provider.get_variant_value(TEST_FLAG_KEY, "fallback", USER_CONTEXT)
+                assert tracker_thread.wait(timeout=2.0), "tracker never ran"
+                assert captured_thread[0] is not calling_thread
+                assert captured_thread[0].name.startswith("exposure")
+            finally:
+                await provider.__aexit__(None, None, None)
+        finally:
+            executor.shutdown(wait=True)
 
     @respx.mock
     async def test_get_all_variants_returns_all_variants_when_user_in_rollout(self):

--- a/mixpanel/flags/test_local_feature_flags.py
+++ b/mixpanel/flags/test_local_feature_flags.py
@@ -648,6 +648,53 @@ class TestLocalFeatureFlagsProviderAsync:
         self._mock_tracker.assert_not_called()
 
     @respx.mock
+    async def test_default_exposure_runs_inline_on_calling_thread(self):
+        """Smoke test: exposure_executor defaults to None, tracker runs inline."""
+        flag = create_test_flag(rollout_percentage=100.0)
+        await self.setup_flags([flag])
+
+        called_on: list[threading.Thread] = []
+
+        def tracker(_distinct_id, _event, _properties):
+            called_on.append(threading.current_thread())
+
+        self._mock_tracker.side_effect = tracker
+        self._flags.get_variant_value(TEST_FLAG_KEY, "fallback", USER_CONTEXT)
+        assert called_on == [threading.current_thread()]
+
+    @respx.mock
+    async def test_track_exposure_event_routes_through_executor(self):
+        """Manual API also honors exposure_executor."""
+        executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="exposure")
+        try:
+            tracker_done = threading.Event()
+            captured: list[threading.Thread] = []
+
+            def tracker(_distinct_id, _event, _properties):
+                captured.append(threading.current_thread())
+                tracker_done.set()
+
+            config = LocalFlagsConfig(
+                enable_polling=False, exposure_executor=executor
+            )
+            provider = LocalFeatureFlagsProvider(
+                "test-token", config, "1.0.0", Mock(side_effect=tracker)
+            )
+            try:
+                provider.track_exposure_event(
+                    "manual",
+                    SelectedVariant(variant_key="treatment", variant_value="x"),
+                    USER_CONTEXT,
+                )
+                assert tracker_done.wait(timeout=2.0)
+                assert captured[0] is not threading.current_thread()
+                assert captured[0].name.startswith("exposure")
+            finally:
+                await provider.__aexit__(None, None, None)
+        finally:
+            executor.shutdown(wait=True)
+
+    @respx.mock
     async def test_exposure_executor_dispatches_tracker_off_calling_thread(self):
         flag = create_test_flag(rollout_percentage=100.0)
         executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="exposure")

--- a/mixpanel/flags/test_local_feature_flags.py
+++ b/mixpanel/flags/test_local_feature_flags.py
@@ -674,9 +674,7 @@ class TestLocalFeatureFlagsProviderAsync:
                 captured.append(threading.current_thread())
                 tracker_done.set()
 
-            config = LocalFlagsConfig(
-                enable_polling=False, exposure_executor=executor
-            )
+            config = LocalFlagsConfig(enable_polling=False, exposure_executor=executor)
             provider = LocalFeatureFlagsProvider(
                 "test-token", config, "1.0.0", Mock(side_effect=tracker)
             )
@@ -708,9 +706,7 @@ class TestLocalFeatureFlagsProviderAsync:
                 tracker_thread.set()
 
             tracker_mock = Mock(side_effect=tracker)
-            config = LocalFlagsConfig(
-                enable_polling=False, exposure_executor=executor
-            )
+            config = LocalFlagsConfig(enable_polling=False, exposure_executor=executor)
             provider = LocalFeatureFlagsProvider(
                 "test-token", config, "1.0.0", tracker_mock
             )

--- a/mixpanel/flags/test_remote_feature_flags.py
+++ b/mixpanel/flags/test_remote_feature_flags.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from unittest.mock import Mock
 
 import httpx
@@ -280,6 +282,45 @@ class TestRemoteFeatureFlagsProviderSync:
             "test_flag", "control", {"distinct_id": "user123"}
         )
         self.mock_tracker.assert_not_called()
+
+    @respx.mock
+    def test_exposure_executor_dispatches_tracker_off_calling_thread(self):
+        respx.get(ENDPOINT).mock(
+            return_value=create_success_response(
+                {
+                    "test_flag": SelectedVariant(
+                        variant_key="treatment", variant_value="treatment"
+                    )
+                }
+            )
+        )
+
+        executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="exposure")
+        try:
+            calling_thread = threading.current_thread()
+            tracker_thread = threading.Event()
+            captured_thread: list[threading.Thread] = []
+
+            def tracker(_distinct_id, _event, _properties):
+                captured_thread.append(threading.current_thread())
+                tracker_thread.set()
+
+            tracker_mock = Mock(side_effect=tracker)
+            config = RemoteFlagsConfig(exposure_executor=executor)
+            provider = RemoteFeatureFlagsProvider(
+                "test-token", config, "1.0.0", tracker_mock
+            )
+            try:
+                provider.get_variant_value(
+                    "test_flag", "control", {"distinct_id": "user123"}
+                )
+                assert tracker_thread.wait(timeout=2.0), "tracker never ran"
+                assert captured_thread[0] is not calling_thread
+                assert captured_thread[0].name.startswith("exposure")
+            finally:
+                provider.__exit__(None, None, None)
+        finally:
+            executor.shutdown(wait=True)
 
     @respx.mock
     def test_is_enabled_returns_true_for_true_variant_value(self):

--- a/mixpanel/flags/test_remote_feature_flags.py
+++ b/mixpanel/flags/test_remote_feature_flags.py
@@ -283,6 +283,57 @@ class TestRemoteFeatureFlagsProviderSync:
         )
         self.mock_tracker.assert_not_called()
 
+    def test_default_exposure_runs_inline_on_calling_thread(self):
+        """Smoke test: exposure_executor defaults to None, tracker runs inline."""
+        called_on: list[threading.Thread] = []
+
+        def tracker(_distinct_id, _event, _properties):
+            called_on.append(threading.current_thread())
+
+        provider = RemoteFeatureFlagsProvider(
+            "test-token", RemoteFlagsConfig(), "1.0.0", tracker
+        )
+        try:
+            provider.track_exposure_event(
+                "manual",
+                SelectedVariant(variant_key="treatment", variant_value="x"),
+                {"distinct_id": "user123"},
+            )
+            assert called_on == [threading.current_thread()]
+        finally:
+            provider.__exit__(None, None, None)
+
+    def test_track_exposure_event_routes_through_executor(self):
+        """Manual API also honors exposure_executor."""
+        executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="exposure")
+        try:
+            tracker_done = threading.Event()
+            captured: list[threading.Thread] = []
+
+            def tracker(_distinct_id, _event, _properties):
+                captured.append(threading.current_thread())
+                tracker_done.set()
+
+            provider = RemoteFeatureFlagsProvider(
+                "test-token",
+                RemoteFlagsConfig(exposure_executor=executor),
+                "1.0.0",
+                Mock(side_effect=tracker),
+            )
+            try:
+                provider.track_exposure_event(
+                    "manual",
+                    SelectedVariant(variant_key="treatment", variant_value="x"),
+                    {"distinct_id": "user123"},
+                )
+                assert tracker_done.wait(timeout=2.0)
+                assert captured[0] is not threading.current_thread()
+                assert captured[0].name.startswith("exposure")
+            finally:
+                provider.__exit__(None, None, None)
+        finally:
+            executor.shutdown(wait=True)
+
     @respx.mock
     def test_exposure_executor_dispatches_tracker_off_calling_thread(self):
         respx.get(ENDPOINT).mock(

--- a/mixpanel/flags/test_utils.py
+++ b/mixpanel/flags/test_utils.py
@@ -2,12 +2,17 @@ from __future__ import annotations
 
 import logging
 import re
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import Future, ThreadPoolExecutor
 from unittest.mock import MagicMock
 
 import pytest
 
-from .utils import dispatch_exposure, generate_traceparent, normalized_hash
+from .utils import (
+    _log_tracker_future_exception,
+    dispatch_exposure,
+    generate_traceparent,
+    normalized_hash,
+)
 
 
 class TestUtils:
@@ -61,3 +66,18 @@ class TestUtils:
             and "tracker exploded" in rec.message
             for rec in caplog.records
         ), f"expected error log, got {[r.message for r in caplog.records]}"
+
+    def test_log_tracker_future_exception_ignores_cancelled_future(self, caplog):
+        # future.exception() on a cancelled future raises CancelledError
+        # (a BaseException, not Exception) — without the guard, that
+        # would escape Future._invoke_callbacks and propagate into e.g.
+        # executor.shutdown(cancel_futures=True).
+        future: Future = Future()
+        assert future.cancel(), "fresh Future should be cancellable"
+
+        with caplog.at_level(logging.ERROR, logger="mixpanel.flags.utils"):
+            _log_tracker_future_exception(future)  # must not raise
+
+        assert not any(
+            "Exposure event failed" in rec.message for rec in caplog.records
+        ), "cancelled futures must not produce an error log"

--- a/mixpanel/flags/test_utils.py
+++ b/mixpanel/flags/test_utils.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import logging
 import re
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import MagicMock
 
 import pytest
 
-from .utils import generate_traceparent, normalized_hash
+from .utils import dispatch_exposure, generate_traceparent, normalized_hash
 
 
 class TestUtils:
@@ -31,3 +34,28 @@ class TestUtils:
         assert result == expected_hash, (
             f"Expected hash of {expected_hash} for '{key}' with salt '{salt}', got {result}"
         )
+
+    def test_dispatch_exposure_runs_inline_when_no_executor(self):
+        tracker = MagicMock()
+
+        dispatch_exposure(tracker, None, "user-1", {"prop": "value"})
+
+        tracker.assert_called_once_with("user-1", "$experiment_started", {"prop": "value"})
+
+    def test_dispatch_exposure_logs_executor_thread_exceptions(self, caplog):
+        # Without the done-callback the future.exception() would be silently
+        # discarded — this test would fail (no log record captured).
+        def boom(*_args, **_kwargs):
+            raise RuntimeError("tracker exploded")
+
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            with caplog.at_level(logging.ERROR, logger="mixpanel.flags.utils"):
+                dispatch_exposure(boom, executor, "user-1", {})
+            # Drain the executor so the done-callback has a chance to fire.
+            executor.shutdown(wait=True)
+
+        assert any(
+            "Exposure event failed on executor thread" in rec.message
+            and "tracker exploded" in rec.message
+            for rec in caplog.records
+        ), f"expected error log, got {[r.message for r in caplog.records]}"

--- a/mixpanel/flags/test_utils.py
+++ b/mixpanel/flags/test_utils.py
@@ -40,7 +40,9 @@ class TestUtils:
 
         dispatch_exposure(tracker, None, "user-1", {"prop": "value"})
 
-        tracker.assert_called_once_with("user-1", "$experiment_started", {"prop": "value"})
+        tracker.assert_called_once_with(
+            "user-1", "$experiment_started", {"prop": "value"}
+        )
 
     def test_dispatch_exposure_logs_executor_thread_exceptions(self, caplog):
         # Without the done-callback the future.exception() would be silently

--- a/mixpanel/flags/types.py
+++ b/mixpanel/flags/types.py
@@ -1,3 +1,4 @@
+from concurrent.futures import Executor
 from typing import Any, Optional
 
 from pydantic import BaseModel, ConfigDict
@@ -10,6 +11,10 @@ class FlagsConfig(BaseModel):
 
     api_host: str = "api.mixpanel.com"
     request_timeout_in_seconds: int = 10
+    # Optional executor used to dispatch exposure-event HTTP sends so flag
+    # evaluation does not block on the network round trip. None (default)
+    # preserves the existing inline behavior.
+    exposure_executor: Optional[Executor] = None
 
 
 class LocalFlagsConfig(FlagsConfig):

--- a/mixpanel/flags/utils.py
+++ b/mixpanel/flags/utils.py
@@ -95,6 +95,12 @@ def dispatch_exposure(
 
 
 def _log_tracker_future_exception(future: Future) -> None:
+    # future.exception() raises CancelledError on a cancelled future,
+    # and CancelledError is a BaseException (not Exception) — it would
+    # escape Future._invoke_callbacks' `except Exception` and propagate
+    # into e.g. executor.shutdown(cancel_futures=True).
+    if future.cancelled():
+        return
     exc = future.exception()
     if exc is not None:
         logger.error(

--- a/mixpanel/flags/utils.py
+++ b/mixpanel/flags/utils.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
+import logging
 import uuid
+from concurrent.futures import Executor, Future
+from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
 
 EXPOSURE_EVENT = "$experiment_started"
 
@@ -47,6 +52,44 @@ def prepare_common_query_params(token: str, sdk_version: str) -> dict[str, str]:
     :return: Dictionary of common query parameters
     """
     return {"mp_lib": "python", "lib_version": sdk_version, "token": token}
+
+
+def dispatch_exposure(
+    tracker: Callable,
+    executor: Executor | None,
+    distinct_id: str,
+    properties: dict[str, Any],
+) -> None:
+    """Invoke the tracker inline or via the configured executor.
+
+    Shared between local and remote flag providers so a change to the
+    dispatch policy only needs to happen in one place.
+    """
+    if executor is None:
+        tracker(distinct_id, EXPOSURE_EVENT, properties)
+        return
+
+    try:
+        future = executor.submit(tracker, distinct_id, EXPOSURE_EVENT, properties)
+    except RuntimeError:
+        logger.exception(
+            "Exposure event dropped — executor refused to accept task"
+        )
+        return
+
+    # Retrieve exceptions raised on the executor thread; otherwise a
+    # tracker raising on the background thread is swallowed by the Future.
+    future.add_done_callback(_log_tracker_future_exception)
+
+
+def _log_tracker_future_exception(future: Future) -> None:
+    exc = future.exception()
+    if exc is not None:
+        logger.error(
+            "Exposure event failed on executor thread: %s: %s",
+            type(exc).__name__,
+            exc,
+        )
 
 
 def generate_traceparent() -> str:

--- a/mixpanel/flags/utils.py
+++ b/mixpanel/flags/utils.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import logging
 import uuid
-from concurrent.futures import Executor, Future
-from typing import Any, Callable
+from typing import TYPE_CHECKING, Any, Callable
+
+if TYPE_CHECKING:
+    from concurrent.futures import Executor, Future
 
 logger = logging.getLogger(__name__)
 
@@ -72,9 +74,7 @@ def dispatch_exposure(
     try:
         future = executor.submit(tracker, distinct_id, EXPOSURE_EVENT, properties)
     except RuntimeError:
-        logger.exception(
-            "Exposure event dropped — executor refused to accept task"
-        )
+        logger.exception("Exposure event dropped — executor refused to accept task")
         return
 
     # Retrieve exceptions raised on the executor thread; otherwise a

--- a/openfeature-provider/README.md
+++ b/openfeature-provider/README.md
@@ -201,6 +201,32 @@ When your application is shutting down, call `shutdown()` to clean up resources:
 provider.shutdown()
 ```
 
+### Async Exposure Tracking
+
+By default, every flag evaluation tracks an exposure event inline — the `/track` HTTP round trip happens on the calling thread before `get_*_value()` returns. For latency-sensitive code paths, pass a `concurrent.futures.Executor` so exposure tracking runs off-thread:
+
+```python
+from concurrent.futures import ThreadPoolExecutor
+from mixpanel.flags.types import LocalFlagsConfig
+
+exposure_executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="mixpanel-exposure")
+provider = MixpanelProvider.from_local_config(
+    "YOUR_PROJECT_TOKEN",
+    LocalFlagsConfig(exposure_executor=exposure_executor),
+)
+
+# Flag evaluation now returns as soon as the local logic finishes;
+# the exposure POST runs on the executor.
+client = api.get_client()
+client.get_boolean_value("my-feature", False)
+
+# On shutdown, drain the executor so in-flight exposures get sent.
+provider.shutdown()
+exposure_executor.shutdown(wait=True)
+```
+
+The same option lives on `RemoteFlagsConfig`. Defaults to `None` (inline behavior); existing setups are unaffected. The async (`a*`) methods already dispatch exposure tracking via `asyncio.create_task` and ignore `exposure_executor`.
+
 ## Context Mapping
 
 ### All Properties Passed Directly


### PR DESCRIPTION
## Summary

Exposure tracking on the sync path called the user's tracker — and therefore an HTTP POST — inline, blocking every `get_variant` / `get_variant_value` / `is_enabled` call by the full `/track` round trip. The async paths already use `asyncio.create_task`; only the sync paths were paying the cost.

Add an optional `exposure_executor: concurrent.futures.Executor | None = None` field to `FlagsConfig` (inherited by both `LocalFlagsConfig` and `RemoteFlagsConfig`). When set, the sync providers dispatch the tracker call via `executor.submit`; flag evaluation returns as soon as the local logic finishes. `None` (the default) preserves the existing inline behavior — no breaking change for current users.

## Usage

```python
from concurrent.futures import ThreadPoolExecutor
from mixpanel.flags.types import LocalFlagsConfig

executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="mixpanel-exposure")
config = LocalFlagsConfig(exposure_executor=executor)
```

## Context

Linear: [SDK-80](https://linear.app/mixpanel/issue/SDK-80/synchronous-reportexposure-blocks-eval-on-http). Mirrors [mixpanel-java#85](https://github.com/mixpanel/mixpanel-java/pull/85). Audit-driven; same fix being applied to mixpanel-ruby and mixpanel-go in parallel PRs.

## Test plan

- [x] Full flags suite passes (83 tests, including the existing inline-exposure tests — `exposure_executor=None` keeps the old behavior unchanged)
- [x] New test on both sync local and sync remote providers asserts the tracker runs on the executor's thread (`thread_name_prefix="exposure"`) and not the calling thread

