### PR TITLE
chore(openfeature): pin mixpanel >=5.3.0 for FallbackReason (SDK-126)

### DIFF
--- a/openfeature-provider/pyproject.toml
+++ b/openfeature-provider/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mixpanel-openfeature"
-version = "0.1.0"
+version = "0.2.0"
 description = "OpenFeature provider for the Mixpanel Python SDK"
 license = "Apache-2.0"
 authors = [
@@ -12,7 +12,7 @@ authors = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "mixpanel>=5.1.0,<6",
+    "mixpanel>=5.3.0,<6",
     "openfeature-sdk>=0.7.0",
 ]
 

--- a/openfeature-provider/pyproject.toml
+++ b/openfeature-provider/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mixpanel-openfeature"
-version = "0.2.0"
+version = "0.1.0"
 description = "OpenFeature provider for the Mixpanel Python SDK"
 license = "Apache-2.0"
 authors = [


### PR DESCRIPTION
## Summary

Follow-up to SDK-79. Now that `openfeature-provider/src/mixpanel_openfeature/provider.py` dereferences `SelectedVariant.fallback_reason` (`_fallback_details`), the `mixpanel-openfeature` PyPI package must not resolve against a base `mixpanel` version that predates that field, or every `resolve_*_details` call raises `AttributeError`.

Currently the wrapper's dep is `mixpanel>=5.1.0,<6`. Both published versions in that range (5.1.0, 5.2.0) predate #180's merge — so the wrapper is currently broken when installed against either.

## Changes

- `openfeature-provider/pyproject.toml`: bump `mixpanel>=5.1.0,<6` → `mixpanel>=5.3.0,<6`
- `openfeature-provider/pyproject.toml`: bump wrapper version `0.1.0` → `0.2.0` (new capability surface)

## Merge sequencing

CI is expected to fail until mixpanel 5.3.0 is published with the SDK-79 changes. That failure is the point — it forces the correct release order:

1. Cut mixpanel 5.3.0 (containing #180 / SDK-79)
2. Rebase/rebuild this PR — CI passes
3. Merge and publish mixpanel-openfeature 0.2.0

Same pattern as [mixpanel/mixpanel-ruby#166](https://github.com/mixpanel/mixpanel-ruby/pull/166) for Ruby.

## Test plan

- [ ] Confirm CI fails now (5.3.0 not on PyPI yet — expected)
- [ ] Once mixpanel 5.3.0 is released, verify CI passes
- [ ] Verify installing `mixpanel-openfeature==0.2.0` against `mixpanel==5.2.0` raises a dependency-resolution error rather than a runtime `AttributeError`

Refs: [SDK-126](https://linear.app/mixpanel/issue/SDK-126), [SDK-79](https://linear.app/mixpanel/issue/SDK-79)

🤖 Generated with [Claude Code](https://claude.com/claude-code)