### PR TITLE
chore: pin ruff to 0.15.22

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,9 +13,9 @@ jobs:
     - name: Install uv
       uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5
     - name: Check formatting
-      run: uvx ruff format --check .
+      run: uvx ruff@0.15.22 format --check .
     - name: Check linting
-      run: uvx ruff check .
+      run: uvx ruff@0.15.22 check .
 
   test:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Summary

`uvx ruff` (no version specifier) resolves to whatever ruff is latest — `0.16.0` just released and changed two things simultaneously:

1. Format now rewrites Python code blocks inside `.md` files (caught `README.md` + `.github/copilot-instructions.md`).
2. Lint added `CPY001` (missing copyright header) among other new rules, which the repo's `select = ["ALL"]` config picks up automatically.

Both failures started hitting master pushes as soon as uvx resolved 0.16 — see [run 30390726259](https://github.com/mixpanel/mixpanel-python/actions/runs/30390726259/job/90381333296) on this PR (lint) and [run 30389789981](https://github.com/mixpanel/mixpanel-python/actions/runs/30389789981) (format) on the previous master push.

## Fix

Pin `uvx ruff@0.15.22` in the two lint job commands. That's the last stable release before the 0.16 shift.

`select = ["ALL"]` is inherently unstable across ruff minor releases — every new release adds new rules. Pinning removes that class of surprise. Longer term, either replace `["ALL"]` with an explicit rule list or bump the pin deliberately (and address any new rules) rather than letting CI auto-adopt them.

## Diff

Two lines in `.github/workflows/test.yml`:
- `uvx ruff format --check .` → `uvx ruff@0.15.22 format --check .`
- `uvx ruff check .` → `uvx ruff@0.15.22 check .`

## Test plan

- [x] Local `ruff 0.15.22` — `format --check .` → 16 files formatted. `check .` → **All checks passed.**
- [ ] CI on this PR should pass both `Check formatting` and `Check linting` steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)