### PR TITLE
fix(BufferedConsumer): don't resend delivered batches after a partial flush failure

### DIFF
--- a/mixpanel/__init__.py
+++ b/mixpanel/__init__.py
@@ -969,4 +969,4 @@ class BufferedConsumer:
                 mp_e.endpoint = endpoint
                 raise mp_e from orig_e
             buf = buf[self._max_size :]
-        self._buffers[endpoint] = buf
+            self._buffers[endpoint] = buf

--- a/test_mixpanel.py
+++ b/test_mixpanel.py
@@ -843,6 +843,30 @@ class TestBufferedConsumer:
             assert excinfo.value.message == f"[{broken_json}]"
             assert excinfo.value.endpoint == "events"
 
+    def test_partial_flush_does_not_resend_delivered_batches(self):
+        """A batch the server accepted must not be re-sent when a later one fails."""
+
+        class FlakyConsumer:
+            def __init__(self):
+                self.log = []
+                self.calls = 0
+
+            def send(self, endpoint, event, api_key=None):
+                self.calls += 1
+                if self.calls == 2:
+                    raise mixpanel.MixpanelException("network error")
+                self.log.append(json.loads(event))
+
+        consumer = mixpanel.BufferedConsumer(2)
+        consumer._consumer = FlakyConsumer()
+        consumer._buffers["events"] = ['"a"', '"b"', '"c"', '"d"']
+
+        with pytest.raises(mixpanel.MixpanelException):
+            consumer.flush()
+
+        assert consumer._consumer.log == [["a", "b"]]
+        assert consumer._buffers["events"] == ['"c"', '"d"']
+
     def test_send_remembers_api_key(self):
         self.consumer.send("imports", '"Event"', api_key="MY_API_KEY")
         assert len(self.log) == 0


### PR DESCRIPTION
`BufferedConsumer._flush_endpoint` only writes the trimmed buffer back after the loop finishes, so when a later batch fails the earlier ones stay in the buffer even though the server already took them. The next flush sends them a second time.

It needs more than `max_size` messages queued to bite, which is what you get after any failed flush, since `send()` keeps appending to a buffer it couldn't drain.

With `max_size=2` and a network that drops the first and third attempts:

```python
bc = BufferedConsumer(max_size=2)
for ev in ['"a"', '"b"', '"c"', '"d"']:
    try:
        bc.send("events", ev)
    except MixpanelException:
        pass
bc.flush()
```

The API receives `["a","b"]`, then `["a","b"]` again, then `["c","d"]`. Same events, twice. Moving the write inside the loop keeps anything already delivered out of the buffer.

The new test fails on master with `['"a"', '"b"', '"c"', '"d"'] == ['"c"', '"d"']` and passes with the change. Full suite is 57 passing.

#16 and #54 both touched this code, but they were about concurrent flushes from `mixpanel-python-async` and were closed as belonging in that wrapper. This one doesn't involve threads.
