### PR TITLE
Local flag evaluation drops users whose rollout context value is 0 or False

### DIFF
--- a/mixpanel/flags/local_feature_flags.py
+++ b/mixpanel/flags/local_feature_flags.py
@@ -233,7 +233,7 @@ class LocalFeatureFlagsProvider:
             logger.warning("Cannot find flag definition for key: '%s'", flag_key)
             return fallback_value.as_fallback(FallbackReason.flag_not_found())
 
-        if not (context_value := context.get(flag_definition.context)):
+        if (context_value := context.get(flag_definition.context)) is None:
             logger.warning(
                 "The rollout context, '%s' for flag, '%s' is not present in the supplied context dictionary",
                 flag_definition.context,

--- a/mixpanel/flags/test_local_feature_flags.py
+++ b/mixpanel/flags/test_local_feature_flags.py
@@ -833,6 +833,30 @@ class TestLocalFeatureFlagsProviderAsync:
         assert result.fallback_reason.message == "distinct_id"
 
     @respx.mock
+    async def test_get_variant_evaluates_zero_context_value(self):
+        flag = create_test_flag(context="account_age_days")
+        await self.setup_flags([flag])
+        fallback = SelectedVariant(variant_value="fb")
+        result = self._flags.get_variant(
+            TEST_FLAG_KEY,
+            fallback,
+            {"distinct_id": DISTINCT_ID, "account_age_days": 0},
+        )
+        assert result.variant_source == VariantSource.LOCAL
+
+    @respx.mock
+    async def test_get_variant_evaluates_false_context_value(self):
+        flag = create_test_flag(context="is_subscriber")
+        await self.setup_flags([flag])
+        fallback = SelectedVariant(variant_value="fb")
+        result = self._flags.get_variant(
+            TEST_FLAG_KEY,
+            fallback,
+            {"distinct_id": DISTINCT_ID, "is_subscriber": False},
+        )
+        assert result.variant_source == VariantSource.LOCAL
+
+    @respx.mock
     async def test_get_variant_tags_no_rollout_match(self):
         flag = create_test_flag(rollout_percentage=0.0)
         await self.setup_flags([flag])


### PR DESCRIPTION
Local flag evaluation reads the rollout context with a truthiness check:

```python
if not (context_value := context.get(flag_definition.context)):
```

A context value of `0` or `False` takes the missing-key branch. The user gets the fallback, the reason attached to it is `MISSING_CONTEXT_KEY`, and the log reports the key as absent from a dictionary that contains it.

Falsy values are legitimate here. `context_value` is typed `Any` and the only thing done with it is `normalized_hash(str(context_value), salt)`, so `0` buckets as `"0"` the same way `1` buckets as `"1"`. The docstring describes the context as the distinct_id "and any other attributes needed for rollout evaluation", and attributes like a purchase count or a subscription boolean are falsy for a large share of users.

```
flag context "account_age_days", user context {"distinct_id": "u1", "account_age_days": 0}
before  ->  fallback, MISSING_CONTEXT_KEY
after   ->  the assigned variant
```

Anyone bucketed on a numeric or boolean property is excluded from every locally evaluated flag on that property, and the fallback reason points at the caller for an argument they passed.

Two tests added next to `test_get_variant_tags_missing_context`, one for `0` and one for `False`. Both fail on master. The existing test for an absent key still passes untouched, which is the half I wanted to be sure of. Full suite 170 passed on 3.9.

One judgement call worth your eyes: `is None` means an empty string now counts as present and gets hashed instead of falling back. That seemed right, since the message and the reason are both about presence, but it's your call.
