### PR TITLE
feat: Toggleable `use_https` param for flags

### DIFF
--- a/mixpanel/flags/local_feature_flags.py
+++ b/mixpanel/flags/local_feature_flags.py
@@ -70,8 +70,9 @@ class LocalFeatureFlagsProvider:
         else:
             auth = httpx.BasicAuth(token, "")
 
+        scheme = "https" if config.use_https else "http"
         httpx_client_parameters = {
-            "base_url": f"https://{config.api_host}",
+            "base_url": f"{scheme}://{config.api_host}",
             "headers": REQUEST_HEADERS,
             "auth": auth,
             "timeout": httpx.Timeout(config.request_timeout_in_seconds),

--- a/mixpanel/flags/remote_feature_flags.py
+++ b/mixpanel/flags/remote_feature_flags.py
@@ -63,8 +63,9 @@ class RemoteFeatureFlagsProvider:
         else:
             auth = httpx.BasicAuth(token, "")
 
+        scheme = "https" if config.use_https else "http"
         httpx_client_parameters = {
-            "base_url": f"https://{config.api_host}",
+            "base_url": f"{scheme}://{config.api_host}",
             "headers": REQUEST_HEADERS,
             "auth": auth,
             "timeout": httpx.Timeout(config.request_timeout_in_seconds),

--- a/mixpanel/flags/test_local_feature_flags.py
+++ b/mixpanel/flags/test_local_feature_flags.py
@@ -1094,3 +1094,66 @@ def test_sync_context_manager_exit_closes_both_clients():
 
     assert provider._sync_client.is_closed
     assert provider._async_client.is_closed
+
+
+def _make_provider(**config_kwargs):
+    config = LocalFlagsConfig(enable_polling=False, **config_kwargs)
+    return LocalFeatureFlagsProvider("test-token", config, "1.0.0", Mock())
+
+
+def test_use_https_defaults_to_true():
+    assert LocalFlagsConfig().use_https is True
+
+
+def test_default_config_uses_https_base_url():
+    provider = _make_provider()
+
+    assert str(provider._sync_client.base_url) == "https://api.mixpanel.com"
+    assert str(provider._async_client.base_url) == "https://api.mixpanel.com"
+
+    provider.shutdown()
+
+
+def test_explicit_use_https_true_matches_default():
+    provider = _make_provider(use_https=True)
+
+    assert str(provider._sync_client.base_url) == "https://api.mixpanel.com"
+    assert str(provider._async_client.base_url) == "https://api.mixpanel.com"
+
+    provider.shutdown()
+
+
+def test_use_https_false_uses_http_base_url():
+    provider = _make_provider(use_https=False)
+
+    assert str(provider._sync_client.base_url) == "http://api.mixpanel.com"
+    assert str(provider._async_client.base_url) == "http://api.mixpanel.com"
+
+    provider.shutdown()
+
+
+def test_use_https_false_builds_full_http_definitions_url():
+    provider = _make_provider(api_host="host.minikube.internal/tproxy", use_https=False)
+
+    for client in (provider._sync_client, provider._async_client):
+        request = client.build_request(
+            "GET", LocalFeatureFlagsProvider.FLAGS_DEFINITIONS_URL_PATH
+        )
+        assert (
+            str(request.url) == "http://host.minikube.internal/tproxy/flags/definitions"
+        )
+
+    provider.shutdown()
+
+
+def test_scheme_headers_stay_https_when_use_https_false():
+    """The backend's auth rejects requests not marked as https, so these
+    headers must not follow the transport scheme (see utils.REQUEST_HEADERS).
+    """
+    provider = _make_provider(use_https=False)
+
+    for client in (provider._sync_client, provider._async_client):
+        assert client.headers["X-Forwarded-Proto"] == "https"
+        assert client.headers["X-Scheme"] == "https"
+
+    provider.shutdown()

--- a/mixpanel/flags/test_remote_feature_flags.py
+++ b/mixpanel/flags/test_remote_feature_flags.py
@@ -652,3 +652,62 @@ def test_sync_context_manager_exit_closes_both_clients():
 
     assert provider._sync_client.is_closed
     assert provider._async_client.is_closed
+
+
+def _make_provider(**config_kwargs):
+    config = RemoteFlagsConfig(**config_kwargs)
+    return RemoteFeatureFlagsProvider("test-token", config, "1.0.0", Mock())
+
+
+def test_use_https_defaults_to_true():
+    assert RemoteFlagsConfig().use_https is True
+
+
+def test_default_config_uses_https_base_url():
+    provider = _make_provider()
+
+    assert str(provider._sync_client.base_url) == "https://api.mixpanel.com"
+    assert str(provider._async_client.base_url) == "https://api.mixpanel.com"
+
+    provider.shutdown()
+
+
+def test_explicit_use_https_true_matches_default():
+    provider = _make_provider(use_https=True)
+
+    assert str(provider._sync_client.base_url) == "https://api.mixpanel.com"
+    assert str(provider._async_client.base_url) == "https://api.mixpanel.com"
+
+    provider.shutdown()
+
+
+def test_use_https_false_uses_http_base_url():
+    provider = _make_provider(use_https=False)
+
+    assert str(provider._sync_client.base_url) == "http://api.mixpanel.com"
+    assert str(provider._async_client.base_url) == "http://api.mixpanel.com"
+
+    provider.shutdown()
+
+
+def test_use_https_false_builds_full_http_flags_url():
+    provider = _make_provider(api_host="host.minikube.internal/tproxy", use_https=False)
+
+    for client in (provider._sync_client, provider._async_client):
+        request = client.build_request("GET", RemoteFeatureFlagsProvider.FLAGS_URL_PATH)
+        assert str(request.url) == "http://host.minikube.internal/tproxy/flags"
+
+    provider.shutdown()
+
+
+def test_scheme_headers_stay_https_when_use_https_false():
+    """The backend's auth rejects requests not marked as https, so these
+    headers must not follow the transport scheme (see utils.REQUEST_HEADERS).
+    """
+    provider = _make_provider(use_https=False)
+
+    for client in (provider._sync_client, provider._async_client):
+        assert client.headers["X-Forwarded-Proto"] == "https"
+        assert client.headers["X-Scheme"] == "https"
+
+    provider.shutdown()

--- a/mixpanel/flags/types.py
+++ b/mixpanel/flags/types.py
@@ -31,6 +31,10 @@ class FlagsConfig:
     # evaluation does not block on the network round trip. None (default)
     # preserves the existing inline behavior.
     exposure_executor: Optional[Executor] = None
+    # Scheme used to reach api_host. True (default) uses https. Set to False
+    # only to reach a local/dev endpoint served over plain HTTP (e.g. a development
+    # nginx proxy), which avoids needing a TLS cert the client can verify.
+    use_https: bool = True
 
 
 @dataclass

--- a/mixpanel/flags/utils.py
+++ b/mixpanel/flags/utils.py
@@ -41,6 +41,10 @@ def close_async_client_from_sync(client: httpx.AsyncClient) -> None:
     )
 
 
+# The scheme headers are intentionally always "https", even when a provider is
+# configured with use_https=False. They describe the original request's scheme
+# to the flags backend, whose auth rejects requests not marked as https, so a
+# proxy fronting a plain-HTTP dev endpoint still needs to see https here.
 REQUEST_HEADERS: dict[str, str] = {
     "X-Scheme": "https",
     "X-Forwarded-Proto": "https",


### PR DESCRIPTION
Defaults to true. Allows disabling `use_https` to allow passing through http connections without cert checking or failing the TLS handshake. To be used for dev / local environments.